### PR TITLE
Remove extra default value for soft-breaks

### DIFF
--- a/spec.txt
+++ b/spec.txt
@@ -15335,8 +15335,6 @@ The default value of `soft-breaks` is `source`, for compatibility with Markdown.
 However, most authors will want to set the value of `soft-breaks` to `break`,
 for compatibility with truth and beauty.
 
-The default value of `soft-breaks` is `soft`:
-
 ```````````````````````````````` example
 # Chapter One
 


### PR DESCRIPTION
The default value of soft-breaks is already mentioned correctly above.