### PR TITLE
Add book/course shared content syntax (0.31.47)

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -114,7 +114,7 @@ $(document).ready(function() {
 </head>
 <body>
 <h1 class="title">Markua Spec</h1>
-<div class="version">Version 0.31.46 (2026-06-09)</div>
+<div class="version">Version 0.31.47 (2026-06-17)</div>
 <div class="authors">
     <span class="author"><em>This formal specification of Markua was developed at <a href="https://leanpub.com">Leanpub</a>, is written by Peter Armstrong, is based on the CommonMark Spec (version 0.31.2) by John MacFarlane, and is licensed under the Creative Commons license CC-BY-SA 4.0.</em><br/><br/><hr/><br/>NOTE: If you are a Leanpub author, there are two different versions of Markua used on Leanpub. <strong>The default version of Markua for books on Leanpub is Markua 0.30, which is documented in this specification, and which is currently in beta on Leanpub.</strong> The default version of Markua for courses on Leanpub is still Markua 0.10, which is documented in <a href="https://leanpub.com/markua/read">The Markua Manual</a>. (You can still use Markua 0.10 and Leanpub Flavoured Markdown for books on Leanpub, of course.)<br/><br/><hr/><br/></span>
 </div>
@@ -249,33 +249,40 @@ $(document).ready(function() {
 <li><a href="#question-alternates-m-"><span class="number">9.9</span>Question alternates (M)</a></li>
 </ul>
 </li>
-<li><a href="#inlines"><span class="number">10</span>Inlines</a>
+<li><a href="#sharing-content-between-books-and-courses-m-"><span class="number">10</span>Sharing content between books and courses (M)</a>
 <ul>
-<li><a href="#code-spans"><span class="number">10.1</span>Code spans</a></li>
-<li><a href="#emphasis-and-strong-emphasis"><span class="number">10.2</span>Emphasis and strong emphasis</a></li>
-<li><a href="#links"><span class="number">10.3</span>Links</a></li>
-<li><a href="#crosslinks-and-ids-m-"><span class="number">10.4</span>Crosslinks and ids (M)</a></li>
-<li><a href="#smart-crosslinks-m-"><span class="number">10.5</span>Smart crosslinks (M)</a></li>
-<li><a href="#images"><span class="number">10.6</span>Images</a></li>
-<li><a href="#image-resource-attributes-m-"><span class="number">10.7</span>Image resource attributes (M)</a></li>
-<li><a href="#inline-svg-images-m-"><span class="number">10.8</span>Inline SVG images (M)</a></li>
-<li><a href="#image-locations-and-embedding-m-"><span class="number">10.9</span>Image locations and embedding (M)</a></li>
-<li><a href="#video-resources-m-"><span class="number">10.10</span>Video resources (M)</a></li>
-<li><a href="#iframe-resources-m-"><span class="number">10.11</span>IFrame resources (M)</a></li>
-<li><a href="#audio-resources-m-"><span class="number">10.12</span>Audio resources (M)</a></li>
-<li><a href="#math-resources-m-"><span class="number">10.13</span>Math resources (M)</a></li>
-<li><a href="#autolinks"><span class="number">10.14</span>Autolinks</a></li>
-<li><a href="#no-raw-html-m-"><span class="number">10.15</span>No raw HTML (M)</a></li>
-<li><a href="#hard-line-breaks"><span class="number">10.16</span>Hard line breaks</a></li>
-<li><a href="#soft-line-breaks"><span class="number">10.17</span>Soft line breaks</a></li>
-<li><a href="#character-substitutions-m-"><span class="number">10.18</span>Character substitutions (M)</a></li>
-<li><a href="#footnotes-and-endnotes-m-"><span class="number">10.19</span>Footnotes and endnotes (M)</a></li>
-<li><a href="#underline-m-"><span class="number">10.20</span>Underline (M)</a></li>
-<li><a href="#superscript-and-subscript-m-"><span class="number">10.21</span>Superscript and subscript (M)</a></li>
-<li><a href="#strikethrough-gfm-"><span class="number">10.22</span>Strikethrough (GFM)</a></li>
-<li><a href="#index-entries-m-"><span class="number">10.23</span>Index entries (M)</a></li>
-<li><a href="#syntactic-sugar-list-m-"><span class="number">10.24</span>Syntactic sugar list (M)</a></li>
-<li><a href="#textual-content"><span class="number">10.25</span>Textual content</a></li>
+<li><a href="#the-book-and-course-blocks-m-"><span class="number">10.1</span>The book and course blocks (M)</a></li>
+<li><a href="#the-only-span-attribute-m-"><span class="number">10.2</span>The only span attribute (M)</a></li>
+<li><a href="#quizzes-and-exercises-are-course-only-by-default-m-"><span class="number">10.3</span>Quizzes and exercises are course-only by default (M)</a></li>
+</ul>
+</li>
+<li><a href="#inlines"><span class="number">11</span>Inlines</a>
+<ul>
+<li><a href="#code-spans"><span class="number">11.1</span>Code spans</a></li>
+<li><a href="#emphasis-and-strong-emphasis"><span class="number">11.2</span>Emphasis and strong emphasis</a></li>
+<li><a href="#links"><span class="number">11.3</span>Links</a></li>
+<li><a href="#crosslinks-and-ids-m-"><span class="number">11.4</span>Crosslinks and ids (M)</a></li>
+<li><a href="#smart-crosslinks-m-"><span class="number">11.5</span>Smart crosslinks (M)</a></li>
+<li><a href="#images"><span class="number">11.6</span>Images</a></li>
+<li><a href="#image-resource-attributes-m-"><span class="number">11.7</span>Image resource attributes (M)</a></li>
+<li><a href="#inline-svg-images-m-"><span class="number">11.8</span>Inline SVG images (M)</a></li>
+<li><a href="#image-locations-and-embedding-m-"><span class="number">11.9</span>Image locations and embedding (M)</a></li>
+<li><a href="#video-resources-m-"><span class="number">11.10</span>Video resources (M)</a></li>
+<li><a href="#iframe-resources-m-"><span class="number">11.11</span>IFrame resources (M)</a></li>
+<li><a href="#audio-resources-m-"><span class="number">11.12</span>Audio resources (M)</a></li>
+<li><a href="#math-resources-m-"><span class="number">11.13</span>Math resources (M)</a></li>
+<li><a href="#autolinks"><span class="number">11.14</span>Autolinks</a></li>
+<li><a href="#no-raw-html-m-"><span class="number">11.15</span>No raw HTML (M)</a></li>
+<li><a href="#hard-line-breaks"><span class="number">11.16</span>Hard line breaks</a></li>
+<li><a href="#soft-line-breaks"><span class="number">11.17</span>Soft line breaks</a></li>
+<li><a href="#character-substitutions-m-"><span class="number">11.18</span>Character substitutions (M)</a></li>
+<li><a href="#footnotes-and-endnotes-m-"><span class="number">11.19</span>Footnotes and endnotes (M)</a></li>
+<li><a href="#underline-m-"><span class="number">11.20</span>Underline (M)</a></li>
+<li><a href="#superscript-and-subscript-m-"><span class="number">11.21</span>Superscript and subscript (M)</a></li>
+<li><a href="#strikethrough-gfm-"><span class="number">11.22</span>Strikethrough (GFM)</a></li>
+<li><a href="#index-entries-m-"><span class="number">11.23</span>Index entries (M)</a></li>
+<li><a href="#syntactic-sugar-list-m-"><span class="number">11.24</span>Syntactic sugar list (M)</a></li>
+<li><a href="#textual-content"><span class="number">11.25</span>Textual content</a></li>
 </ul>
 </li>
 <li><a href="#appendix-a-parsing-strategy">Appendix: A parsing strategy</a>
@@ -3510,6 +3517,7 @@ the defaults are in one list. These defaults are listed below.</p>
   default-random-question-order: false
   default-table-column-spacing: 6pt
   figure-classes: all
+  include-exercises-in-book: false
   include-page-numbers-in-references: true
   italicize-underlines: true
   lang: eng
@@ -3592,6 +3600,13 @@ of their <code>class</code> attribute. An example of this setting is:
 figures are listed, either grouped by their class or together in one big list,
 is controlled by the <code>list-figures</code> setting. Note that the numbering of figures
 is controlled by the <code>number-figures</code> setting.</p>
+<p><code>include-exercises-in-book</code>
+: <code>true</code> or <code>false</code>. The default value is <code>false</code>. Quizzes and exercises are
+intrinsically course content, so by default they are dropped from book outputs
+(PDF, EPUB, etc.) and kept only in course outputs. If you are writing a workbook,
+study guide or instructor manual and want quizzes and exercises to appear in the
+book output as well, set this to <code>true</code>. This setting is discussed in the
+<a href="#sharing-content-between-books-and-courses-m-">section on sharing content between books and courses</a>.</p>
 <p><code>include-page-numbers-in-references</code>
 : <code>true</code> or <code>false</code>. The default value is <code>true</code>. When a smart crosslink to a
 figure reference is inserted with <code>#f</code>, this setting determines how the
@@ -13681,8 +13696,98 @@ administered to hundreds–or thousands, or tens of thousands–of people with a
 incorrect number of questions, or with questions incorrectly used as alternates
 for each other, would be much more difficult.</p>
 </div>
+<div class="extension">
+<h1 id="sharing-content-between-books-and-courses-m-" class="definition">
+<span class="number">10</span>Sharing content between books and courses (M)
+</h1>
+<p>As discussed in the chapter on quizzes and exercises, a single Markua document
+can be generated both as a book and as a course. Most of the prose is shared
+between the two, but quite often a particular section belongs to only one of
+them. For example, a course might contain a “watch the video, then answer the
+quiz” introduction that makes no sense in the printed book, while the book might
+contain a “since you can’t click anything on paper, here is the full transcript”
+passage that is redundant in the course.</p>
+<p>Markua provides three constructs for this: two block-level (<code>{book}</code> and
+<code>{course}</code>), and one inline (the <code>only</code> span attribute). It also has an implicit
+rule that quizzes and exercises are course-only by default.</p>
+<p>Whenever this section refers to the “target”, it means whether the Markua
+Processor is currently generating a book (the PDF, EPUB and equivalent web
+outputs) or a course. The same source document produces both; these constructs
+simply let you gate content on which one is being generated.</p>
+<h2 id="the-book-and-course-blocks-m-" class="definition">
+<span class="number">10.1</span>The book and course blocks (M)
+</h2>
+<p>The <code>{book}</code> and <code>{course}</code> block syntaxes are similar to the syntaxes for
+asides and blurbs:</p>
+<ol>
+<li>By wrapping the content in <code>{book}</code> … <code>{/book}</code>, for content which should
+be included only in book outputs.</li>
+<li>By wrapping the content in <code>{course}</code> … <code>{/course}</code>, for content which
+should be included only in course outputs.</li>
+</ol>
+<p>When the target is a book, the content inside a <code>{book}</code> block is included
+exactly as if the <code>{book}</code> and <code>{/book}</code> wrapper were not there, and any
+<code>{course}</code> blocks are dropped entirely. When the target is a course, the
+reverse happens: <code>{course}</code> blocks are unwrapped and <code>{book}</code> blocks are
+dropped.</p>
+<p>A <code>{book}</code> or <code>{course}</code> block can contain any Markua content, including
+multiple paragraphs, headings, figures, asides, quizzes and so on.</p>
+<p>Here is an example which uses both:</p>
+<pre><code>This paragraph is shared, so it appears in both the book and the course.
+
+{book}
+Since you are reading this on paper, here is the full transcript of the video.
+{/book}
+
+{course}
+Watch the video above, then complete the quiz that follows.
+{/course}
+
+This closing paragraph is also shared.
+</code></pre>
+<p>When this document is generated as a book, the reader sees the shared paragraph,
+the transcript paragraph, and the closing paragraph. When it is generated as a
+course, the reader sees the shared paragraph, the “watch the video” paragraph,
+and the closing paragraph.</p>
+<h2 id="the-only-span-attribute-m-" class="definition">
+<span class="number">10.2</span>The only span attribute (M)
+</h2>
+<p>For inline content which is too small to justify a block, you can instead add an
+<code>only</code> attribute to a <a href="#span-attribute-lists">span</a>. The value is the target
+that the span should be included for: either <code>book</code> or <code>course</code>.</p>
+<pre><code>The next release ships [in print on June 1st]{only: book}[as twelve video
+lessons]{only: course}.
+</code></pre>
+<p>When the target is a book, a span with <code>only: book</code> is kept (with the <code>only</code>
+attribute removed, so downstream output never sees it) and a span with
+<code>only: course</code> is dropped. When the target is a course, the reverse happens.</p>
+<p>The value may also be a comma-separated list, for the rare case where you want
+to be explicit that a span belongs to more than one target:</p>
+<pre><code>This applies [to both formats]{only: book, course}.
+</code></pre>
+<p>There is deliberately no <code>only: all</code> value: the absence of an <code>only</code> attribute
+already means “include everywhere”, so <code>only: book, course</code> is only ever needed
+when you want to be explicit.</p>
+<h2 id="quizzes-and-exercises-are-course-only-by-default-m-" class="definition">
+<span class="number">10.3</span>Quizzes and exercises are course-only by default (M)
+</h2>
+<p>Quizzes and exercises (discussed <a href="#quizzes-and-exercises-m-">earlier</a>) are
+intrinsically course content. Because of this, a <code>{quiz}</code> or <code>{exercise}</code> block
+is treated as though it were wrapped in a <code>{course}</code> block: it is included in
+course outputs and dropped from book outputs by default. You do not need to wrap
+your quizzes and exercises in <code>{course}</code> blocks to get this behavior; it is
+implicit.</p>
+<p>Sometimes, though, you do want quizzes and exercises in the book output: for
+example, when producing a workbook, a study guide, or an instructor manual. In
+that case, set the <code>include-exercises-in-book</code> document setting to <code>true</code>:</p>
+<pre><code>{include-exercises-in-book: true}
+</code></pre>
+<p>With this setting, <code>{quiz}</code> and <code>{exercise}</code> blocks are kept in book outputs as
+well as course outputs. This document setting is also listed in the
+<a href="#the-standard-document-settings-m-">section on standard document settings</a>.</p>
+</div>
 <h1 id="inlines" class="definition">
-<span class="number">10</span>Inlines
+<span class="number">11</span>Inlines
 </h1>
 <p>Inlines are parsed sequentially from the beginning of the character
 stream to the end (left to right, in left-to-right languages).
@@ -13703,7 +13808,7 @@ Thus, for example, in</p>
 <p><code>hi</code> is parsed as code, leaving the backtick at the end as a literal
 backtick.</p>
 <h2 id="code-spans" class="definition">
-<span class="number">10.1</span>Code spans
+<span class="number">11.1</span>Code spans
 </h2>
 <p>A <a id="backtick-string" href="#backtick-string" class="definition">backtick string</a>
 is a string of one or more backtick characters (<code>`</code>) that is neither
@@ -14055,7 +14160,7 @@ closing backtick strings to be equal in length:</p>
 </div>
 </div>
 <h2 id="emphasis-and-strong-emphasis" class="definition">
-<span class="number">10.2</span>Emphasis and strong emphasis
+<span class="number">11.2</span>Emphasis and strong emphasis
 </h2>
 <p>John Gruber’s original <a href="https://daringfireball.net/projects/markdown/syntax#em">Markdown syntax
 description</a> says:</p>
@@ -16129,7 +16234,7 @@ delimiters:</p>
 </div>
 </div>
 <h2 id="links" class="definition">
-<span class="number">10.3</span>Links
+<span class="number">11.3</span>Links
 </h2>
 <p>A link contains <a href="#link-text">link text</a> (the visible text), a <a href="#link-destination">link destination</a>
 (the URI that is the link destination), and optionally a <a href="#link-title">link title</a>.
@@ -17694,7 +17799,7 @@ is followed by a link label (even though <code>[bar]</code> is not defined):</p>
 </div>
 <div class="extension">
 <h2 id="crosslinks-and-ids-m-" class="definition">
-<span class="number">10.4</span>Crosslinks and ids (M)
+<span class="number">11.4</span>Crosslinks and ids (M)
 </h2>
 <p>There are two parts to making a crosslink.</p>
 <ol>
@@ -17702,7 +17807,7 @@ is followed by a link label (even though <code>[bar]</code> is not defined):</p>
 <li>Reference that id with a crosslink.</li>
 </ol>
 <h3 id="defining-an-id" class="definition">
-<span class="number">10.4.1</span>Defining an id
+<span class="number">11.4.1</span>Defining an id
 </h3>
 <p>There are two ways to define an id:</p>
 <ol>
@@ -17728,7 +17833,7 @@ from anywhere in the Markua document.</p>
 element. Finally, if an id is defined with an invalid name, the Markua Processor
 must ignore it and log an error.</p>
 <h4 id="defining-an-id-on-a-block-element" class="definition">
-<span class="number">10.4.1.1</span>Defining an id on a block element
+<span class="number">11.4.1.1</span>Defining an id on a block element
 </h4>
 <p>To define an id on a block element like a paragraph, figure, heading or even a
 definition list item, you simply stick the id definition on a line above the
@@ -17745,7 +17850,7 @@ attribute:</p>
 This is a paragraph with the id of `some-id`.
 </code></pre>
 <h4 id="defining-an-id-on-a-span-element" class="definition">
-<span class="number">10.4.1.2</span>Defining an id on a span element
+<span class="number">11.4.1.2</span>Defining an id on a span element
 </h4>
 <p>To define an id on a span element you simply add the id definition immediately
 after the span element.</p>
@@ -17770,7 +17875,7 @@ index entries, the <code>id:</code> syntax must be used in a full attribute list
 dogs.
 </code></pre>
 <h3 id="referencing-an-with-a-crosslink" class="definition">
-<span class="number">10.4.2</span>Referencing an <code>id</code> With a Crosslink
+<span class="number">11.4.2</span>Referencing an <code>id</code> With a Crosslink
 </h3>
 <p>Regardless of how you defined the id, you then link to it to create a crosslink.
 To do this, you use the <code>#</code> character and the id in a link:</p>
@@ -17813,7 +17918,7 @@ The<span class="space"> </span>[quick<span class="space"> </span>sly<span class=
 </div>
 </div>
 <h3 id="rules-for-s-and-crosslinks" class="definition">
-<span class="number">10.4.3</span>Rules for <code>id</code>s and Crosslinks
+<span class="number">11.4.3</span>Rules for <code>id</code>s and Crosslinks
 </h3>
 <ul>
 <li>If a Markua document contains duplicate <code>id</code> attribute values, the <strong>first</strong>
@@ -17826,7 +17931,7 @@ Processor. The Markua Processor should also log an error.</li>
 </div>
 <div class="extension">
 <h2 id="smart-crosslinks-m-" class="definition">
-<span class="number">10.5</span>Smart crosslinks (M)
+<span class="number">11.5</span>Smart crosslinks (M)
 </h2>
 <p>Parts, chapters, sections and figures (with titles) often have two useful
 properties for writers:</p>
@@ -17847,7 +17952,7 @@ For EPUB, static page numbers in smart crosslinks make no sense because EPUB
 files have resizable text (and thus the page numbers vary). For HTML, page
 numbers make no sense, period.</p>
 <h3 id="the-simplest-way-to-add-a-smart-crosslink" class="definition">
-<span class="number">10.5.1</span>The simplest way to add a smart crosslink
+<span class="number">11.5.1</span>The simplest way to add a smart crosslink
 </h3>
 <p>The simplest way to use smart crosslinks is to always use them the same way:</p>
 <pre><code>Some text [#f](#its-id) more text.
@@ -17857,7 +17962,7 @@ id referenced by <code>(#its-id)</code>.</p>
 <p>If you like simplicity, stop reading this section now. If you like complexity
 and fine-grained control, please continue!</p>
 <h3 id="the-myriad-ways-to-add-a-smart-crosslink" class="definition">
-<span class="number">10.5.2</span>The myriad ways to add a smart crosslink
+<span class="number">11.5.2</span>The myriad ways to add a smart crosslink
 </h3>
 <p>There are actually a whole bunch of different ways te insert smart crosslinks,
 since you don’t always want to show the full title.</p>
@@ -17977,7 +18082,7 @@ is off, the <code>#f</code> must not include either the <code>#d</code> or <code
 “Anatomy of a Squirrel” not “Figure 8.2: Anatomy of a Squirrel”.</p>
 </div>
 <h2 id="images" class="definition">
-<span class="number">10.6</span>Images
+<span class="number">11.6</span>Images
 </h2>
 <p>Syntax for images is like the syntax for links, with one
 difference. Instead of <a href="#link-text">link text</a>, we have an
@@ -18326,7 +18431,7 @@ backslash-escape the opening <code>[</code>:</p>
 </div>
 <div class="extension">
 <h2 id="image-resource-attributes-m-" class="definition">
-<span class="number">10.7</span>Image resource attributes (M)
+<span class="number">11.7</span>Image resource attributes (M)
 </h2>
 <p>As shown in the Images section, the syntax to insert an image in Markua is
 the identical to that used by CommonMark and GFM. (That section is unchanged
@@ -18480,7 +18585,7 @@ instead, involving a very real and very delicious apple pie:</p>
 </div>
 <div class="extension">
 <h2 id="inline-svg-images-m-" class="definition">
-<span class="number">10.8</span>Inline SVG images (M)
+<span class="number">11.8</span>Inline SVG images (M)
 </h2>
 <p>Local and web resource locations are supported for any type of image; inline
 resource locations are supported for SVG images only.</p>
@@ -18527,7 +18632,7 @@ the SVG image.</p>
 <p>Note that when you are writing about SVG and want to display the SVG text, what
 you are really doing is creating a code resource. This is discussed below.</p>
 <h3 id="writing-about-svg" class="definition">
-<span class="number">10.8.1</span>Writing about SVG
+<span class="number">11.8.1</span>Writing about SVG
 </h3>
 <p>If you want to write about the SVG format, and show the actual SVG source
 (instead of the image produced), it needs to be of a <code>format</code> of <code>code</code>, not
@@ -18588,7 +18693,7 @@ since guessing when neither is present always produces a type of <code>code</cod
 </div>
 <div class="extension">
 <h2 id="image-locations-and-embedding-m-" class="definition">
-<span class="number">10.9</span>Image locations and embedding (M)
+<span class="number">11.9</span>Image locations and embedding (M)
 </h2>
 <p>Note that regardless of the image location, a Markua Processor can handle images
 in the following ways:</p>
@@ -18606,7 +18711,7 @@ GIF, PNG, JPEG, SVG and zipped SVG.</p>
 </div>
 <div class="extension">
 <h2 id="video-resources-m-" class="definition">
-<span class="number">10.10</span>Video resources (M)
+<span class="number">11.10</span>Video resources (M)
 </h2>
 <p>Note that .mp4 is used for MP4 video, not MP4 AAC audio.</p>
 <p>The following are the video resource formats and the file extensions which
@@ -18635,7 +18740,7 @@ work in some Markua Processors, like Leanpub, without specifying either the
 <p>We will discuss the supported and the default attributes for videos, and then
 show examples of videos being inserted for both local and web videos.</p>
 <h3 id="supported-attributes-for-video" class="definition">
-<span class="number">10.10.1</span>Supported Attributes for Video
+<span class="number">11.10.1</span>Supported Attributes for Video
 </h3>
 <p>The following are the supported attributes for video resources, in addition to
 the <code>class</code>, <code>format</code>, <code>title</code> and <code>type</code> attributes which all resources
@@ -18705,7 +18810,7 @@ with images.</p>
 an HTML mapping, please note that a Markua Processor has complete flexibility
 over how it handles the location of video resources and their display.</p>
 <h3 id="local-video" class="definition">
-<span class="number">10.10.2</span>Local Video
+<span class="number">11.10.2</span>Local Video
 </h3>
 <div class="example" id="example-640">
 <div class="examplenum">
@@ -18730,7 +18835,7 @@ Here's<span class="space"> </span>a<span class="space"> </span>paragraph<span cl
 </div>
 </div>
 <h3 id="web-video" class="definition">
-<span class="number">10.10.3</span>Web Video
+<span class="number">11.10.3</span>Web Video
 </h3>
 <div class="example" id="example-641">
 <div class="examplenum">
@@ -18759,7 +18864,7 @@ poster=&quot;https://img.youtube.com/vi/VOCYL-FNbr0/mqdefault.jpg&quot;/&gt;
 </div>
 <div class="extension">
 <h2 id="iframe-resources-m-" class="definition">
-<span class="number">10.11</span>IFrame resources (M)
+<span class="number">11.11</span>IFrame resources (M)
 </h2>
 <p>The syntax to insert an IFrame is almost identical to that is used for video
 resources.</p>
@@ -18771,7 +18876,7 @@ are created in Markua.</p>
 <p>The only resource location which is supported for an IFrame resource is the
 web resource location, for obvious reasons.</p>
 <h3 id="supported-attributes-for-resources" class="definition">
-<span class="number">10.11.1</span>Supported Attributes for <code>iframe</code> Resources
+<span class="number">11.11.1</span>Supported Attributes for <code>iframe</code> Resources
 </h3>
 <p>The following are the supported attributes for IFrame resources, in addition to
 the <code>class</code>, <code>format</code>, <code>title</code> and <code>type</code> attributes which all resources
@@ -18832,7 +18937,7 @@ Here's<span class="space"> </span>a<span class="space"> </span>paragraph<span cl
 </div>
 <div class="extension">
 <h2 id="audio-resources-m-" class="definition">
-<span class="number">10.12</span>Audio resources (M)
+<span class="number">11.12</span>Audio resources (M)
 </h2>
 <p>The following are the audio resource formats and the file extensions which
 choose them by default:</p>
@@ -18870,7 +18975,7 @@ and Ogg Vorbis.</p>
 <p>We will discuss the supported and the default attributes for audio files, and
 then show examples of audio being inserted for both local and web audio files.</p>
 <h3 id="supported-attributes-for-audio" class="definition">
-<span class="number">10.12.1</span>Supported Attributes for Audio
+<span class="number">11.12.1</span>Supported Attributes for Audio
 </h3>
 <p>The following are the supported attributes for audio resources, in addition to
 the <code>class</code>, <code>format</code>, <code>title</code> and <code>type</code> attributes which all resources
@@ -18890,7 +18995,7 @@ this. See the Video resources section above for more information.</p>
 an HTML mapping, please note that a Markua Processor has complete flexibility
 over how it handles the location of video resources and their display.</p>
 <h3 id="local-audio" class="definition">
-<span class="number">10.12.2</span>Local Audio
+<span class="number">11.12.2</span>Local Audio
 </h3>
 <div class="example" id="example-643">
 <div class="examplenum">
@@ -18912,7 +19017,7 @@ over how it handles the location of video resources and their display.</p>
 </div>
 </div>
 <h3 id="web-audio" class="definition">
-<span class="number">10.12.3</span>Web Audio
+<span class="number">11.12.3</span>Web Audio
 </h3>
 <div class="example" id="example-644">
 <div class="examplenum">
@@ -18936,7 +19041,7 @@ over how it handles the location of video resources and their display.</p>
 </div>
 <div class="extension">
 <h2 id="math-resources-m-" class="definition">
-<span class="number">10.13</span>Math resources (M)
+<span class="number">11.13</span>Math resources (M)
 </h2>
 <p>Math can be a local, web or inline resource, just like any other resource, and
 the same resource syntax applies to code as to all other resources.</p>
@@ -18953,7 +19058,7 @@ like transparent SVGs with a dynamic foreground color, or MathJax or MathML.</p>
 </ol>
 <p><strong>Leanpub authors: Note that AsciiMath is currently not implemented in Leanpub.</strong></p>
 <h3 id="math-resource-formats" class="definition">
-<span class="number">10.13.1</span>Math resource formats
+<span class="number">11.13.1</span>Math resource formats
 </h3>
 <p>The following are the math resource formats and the file extensions which
 choose them by default:</p>
@@ -18971,7 +19076,7 @@ display it, then add a <code>{type: code, format: latex}</code> attribute list.<
 <p>Note that the assumption is that AsciiMath will almost always be used as an
 inline resource. So, the <code>.asciimath</code> file extension is deliberately verbose.</p>
 <h3 id="supported-attributes-for-math" class="definition">
-<span class="number">10.13.2</span>Supported Attributes for Math
+<span class="number">11.13.2</span>Supported Attributes for Math
 </h3>
 <p>The following are the supported attribute for math resources, in addition to the
 <code>class</code>, <code>format</code>, <code>title</code> and <code>type</code> attributes which all resources support:</p>
@@ -18989,7 +19094,7 @@ into Markua: <code>latexmath</code> for LaTeX math and <code>asciimath</code> fo
 Markua Processor encounters one of these formats, it must assume the <code>type</code> of
 the resource is <code>math</code>, not <code>code</code>.</p>
 <h3 id="using-bold-and-strikethrough-formatting-with-math" class="definition">
-<span class="number">10.13.3</span>Using bold and strikethrough formatting with math
+<span class="number">11.13.3</span>Using bold and strikethrough formatting with math
 </h3>
 <p>Markua supports formatting math as bold or strikethrough.</p>
 <p>Math can be <code>**bolded**</code> by being wrapped with two asterisks, and can be
@@ -18997,7 +19102,7 @@ formatted in <code>~~strikethrough~~</code> by being wrapped with two tildes. No
 the format of the strikethrough line is controlled by the
 <code>strikethrough-format</code> document setting.</p>
 <h3 id="local-math-resources" class="definition">
-<span class="number">10.13.4</span>Local math resources
+<span class="number">11.13.4</span>Local math resources
 </h3>
 <p>Local math resources can be inserted as a figure.</p>
 <pre><code>Here's a paragraph before the figure.
@@ -19016,7 +19121,7 @@ Here's a paragraph after the figure.
 Here's a paragraph after the figure.
 </code></pre>
 <h3 id="web-math-resources" class="definition">
-<span class="number">10.13.5</span>Web math resources
+<span class="number">11.13.5</span>Web math resources
 </h3>
 <p>This is identical to how local math resources work, including the significance
 of file extensions. The only difference is that the files are on the web.</p>
@@ -19036,14 +19141,14 @@ Here's a paragraph after the figure.
 Here's a paragraph after the figure.
 </code></pre>
 <h3 id="inline-math-resources" class="definition">
-<span class="number">10.13.6</span>Inline math resources
+<span class="number">11.13.6</span>Inline math resources
 </h3>
 <p>Inline math resources are the most flexible way to insert math. They are the only
 way to insert math as a span resource, and the most straightforward way to add
 short math examples as figures. LaTeX math and AsciiMath can be inserted inline
 as a span or figure.</p>
 <h4 id="span" class="definition">
-<span class="number">10.13.6.1</span>Span
+<span class="number">11.13.6.1</span>Span
 </h4>
 <p>Being able to insert a math resource as a span is important, as it lets you write
 things like one of the kinematic equations <code>d = v_i t + \frac{1}{2} a t^2</code>$ inside
@@ -19053,7 +19158,7 @@ an <code>@</code> after the closing backtick for AsciiMath, or an attribute list
 a <code>format</code> of <code>latexmath</code> or <code>asciimath</code>. If none of these is done, the content
 of the backticks is treated as code and is output verbatim as monospaced text.</p>
 <h5 id="latex-math-span" class="definition">
-<span class="number">10.13.6.1.1</span>LaTeX math span
+<span class="number">11.13.6.1.1</span>LaTeX math span
 </h5>
 <p>There is syntactic sugar for LaTeX math which is inserted as a span, using the
 <code>$</code> character after the closing backtick:</p>
@@ -19068,7 +19173,7 @@ sentence.
 inside a sentence.
 </code></pre>
 <h5 id="asciimath-span" class="definition">
-<span class="number">10.13.6.1.2</span>AsciiMath span
+<span class="number">11.13.6.1.2</span>AsciiMath span
 </h5>
 <p><a href="https://asciimath.org/">AsciiMath</a> is a way of producing simple MathML equations,
 using about 1% of the typing. It’s more terse than LaTeX math.</p>
@@ -19083,7 +19188,7 @@ character after the closing backtick:</p>
 inside a sentence.
 </code></pre>
 <h4 id="figure" class="definition">
-<span class="number">10.13.6.2</span>Figure
+<span class="number">11.13.6.2</span>Figure
 </h4>
 <p>LaTeX math and AsciiMath can be inserted inline as a figure.</p>
 <ul>
@@ -19093,7 +19198,7 @@ backticks, or by specifying an attribute list of <code>{format: latexmath}</code
 backticks, or by specifying an attribute list of <code>{format: asciimath}</code>.</li>
 </ul>
 <h5 id="latex-math-figures" class="definition">
-<span class="number">10.13.6.2.1</span>LaTeX math figures
+<span class="number">11.13.6.2.1</span>LaTeX math figures
 </h5>
 <p>Here’s how you do this using LaTeX math…</p>
 <p>Here’s the version with the syntactic sugar for the format after the backticks:</p>
@@ -19134,7 +19239,7 @@ Here's a paragraph after the figure.
 Here's a paragraph after the figure.
 </code></pre>
 <h5 id="asciimath-figures" class="definition">
-<span class="number">10.13.6.2.2</span>AsciiMath figures
+<span class="number">11.13.6.2.2</span>AsciiMath figures
 </h5>
 <p>Here’s how you do this using AsciiMath…</p>
 <p>Here’s the version with the syntactic sugar for the format after the backticks:</p>
@@ -19172,7 +19277,7 @@ text, what you are really doing is creating a code resource. This is essentially
 identical to what was shown earlier in writing about SVG images. It’s also shown
 below.</p>
 <h3 id="writing-about-math" class="definition">
-<span class="number">10.13.7</span>Writing about Math
+<span class="number">11.13.7</span>Writing about Math
 </h3>
 <p>If you want to write about math, and show the actual code (instead of the
 formatted output), it needs to be of a <code>format</code> of <code>code</code>, not <code>math</code>.</p>
@@ -19233,7 +19338,7 @@ abs(sum_(i=1)^n a_i b_i) &lt;= (sum_(i=1)^n a_i^2)^(1/2) (sum_(i=1)^n b_i^2)^(1/
 </code></pre>
 </div>
 <h2 id="autolinks" class="definition">
-<span class="number">10.14</span>Autolinks
+<span class="number">11.14</span>Autolinks
 </h2>
 <p><a id="autolink" href="#autolink" class="definition">Autolink</a>s are absolute URIs and email addresses inside
 <code>&lt;</code> and <code>&gt;</code>. They are parsed as links, with the URL or email address
@@ -19522,7 +19627,7 @@ spec</a>:</p>
 </div>
 <div class="extension">
 <h2 id="no-raw-html-m-" class="definition">
-<span class="number">10.15</span>No raw HTML (M)
+<span class="number">11.15</span>No raw HTML (M)
 </h2>
 <p>As <a href="#markua-s-one-key-subtraction-from-markdown-raw-html-is-removed-m-">discussed</a>,
 Markua does not support raw HTML. <strong>All raw HTML is removed</strong>. As a side-effect,
@@ -19530,7 +19635,7 @@ this means HTML comments can still be used, since they (like all HTML) will be
 removed from the output.</p>
 </div>
 <h2 id="hard-line-breaks" class="definition">
-<span class="number">10.16</span>Hard line breaks
+<span class="number">11.16</span>Hard line breaks
 </h2>
 <p>A line ending (not in a code span or HTML tag) that is preceded
 by two or more spaces and does not occur at the end of a block
@@ -19763,7 +19868,7 @@ other block element:</p>
 </div>
 </div>
 <h2 id="soft-line-breaks" class="definition">
-<span class="number">10.17</span>Soft line breaks
+<span class="number">11.17</span>Soft line breaks
 </h2>
 <p>A regular line ending (not in a code span or HTML tag) that is not
 preceded by two or more spaces or a backslash is parsed as a
@@ -19808,7 +19913,7 @@ line ending or as a space.</p>
 as hard line breaks.</p>
 <div class="extension">
 <h2 id="character-substitutions-m-" class="definition">
-<span class="number">10.18</span>Character substitutions (M)
+<span class="number">11.18</span>Character substitutions (M)
 </h2>
 <p>Markua documents can be written in UTF-8, so to produce any Unicode character, it
 is possible to just use the proper Unicode characters. However, in certain cases,
@@ -19834,7 +19939,7 @@ paragraph).</p>
 : To produce a horizontal ellipsis (…), you can just type <code>...</code>. You can also use
 the proper Unicode character, U+2026, of course.</p>
 <h3 id="optional-automatic-curly-quotes-outside-of-code-blocks-and-spans" class="definition">
-<span class="number">10.18.1</span>Optional Automatic Curly Quotes Outside of Code Blocks and Spans
+<span class="number">11.18.1</span>Optional Automatic Curly Quotes Outside of Code Blocks and Spans
 </h3>
 <p>A Markua Processor may replace the <code>&quot;</code> character with the appropriate “curly
 quote” at its discretion. This lets <code>&quot;typography&quot;</code> become <code>“typography”</code>, and
@@ -19851,11 +19956,11 @@ straight in a code span either.)</p>
 </div>
 <div class="extension">
 <h2 id="footnotes-and-endnotes-m-" class="definition">
-<span class="number">10.19</span>Footnotes and endnotes (M)
+<span class="number">11.19</span>Footnotes and endnotes (M)
 </h2>
 <p>Books often have footnotes and endnotes. So, Markua has them too.</p>
 <h3 id="footnotes" class="definition">
-<span class="number">10.19.1</span>Footnotes
+<span class="number">11.19.1</span>Footnotes
 </h3>
 <p>To add a footnote, you insert a footnote tag using square brackets, a caret and
 the tag, like this:</p>
@@ -19885,7 +19990,7 @@ should output them <em>somewhere</em>, but the details are not specified. This i
 deliberate, in order to maximize implementation flexibility for Markua
 Processors.</p>
 <h3 id="endnotes" class="definition">
-<span class="number">10.19.2</span>Endnotes
+<span class="number">11.19.2</span>Endnotes
 </h3>
 <p>Sometimes endnotes are used instead of footnotes, but other times, these are in
 addition to footnotes. So, it makes sense for Markua to define separate syntaxes
@@ -19911,7 +20016,7 @@ should output them <em>somewhere</em>, but the details are not specified. This i
 deliberate, in order to maximize implementation flexibility for Markua
 Processors.</p>
 <h3 id="single-reference-to-footnotes-and-endnotes" class="definition">
-<span class="number">10.19.3</span>Single reference to footnotes and endnotes
+<span class="number">11.19.3</span>Single reference to footnotes and endnotes
 </h3>
 <p>You can only refer to a footnote or endnote once. You can’t define a footnote or
 endnote in one place and refer to it multiple times in the same Markua document.
@@ -19920,7 +20025,7 @@ Markua document, the best approach is to put it in a section (or sub-section,
 sub-sub-section, etc.) or aside and refer to it from multiple places using a
 <a href="#crosslinks">crosslink</a>.</p>
 <h3 id="footnote-and-endnote-support-is-required-for-paragraphs-only" class="definition">
-<span class="number">10.19.4</span>Footnote and endnote support is required for paragraphs only
+<span class="number">11.19.4</span>Footnote and endnote support is required for paragraphs only
 </h3>
 <p>A Markua Processor must support footnote and endnote references inserted in
 normal paragraph content. However, that’s it.</p>
@@ -19939,7 +20044,7 @@ only supports inserting footnotes or endnotes in normal paragraph content.</p>
 </div>
 <div class="extension">
 <h2 id="underline-m-" class="definition">
-<span class="number">10.20</span>Underline (M)
+<span class="number">11.20</span>Underline (M)
 </h2>
 <p>In Markdown as defined by John Gruber, and in CommonMark and GFM,
 <code>*one asterisk*</code> and <code>_one underscore_</code> both produce <em>italics</em>, and there is no
@@ -20092,7 +20197,7 @@ stuff
 </div>
 <div class="extension">
 <h2 id="superscript-and-subscript-m-" class="definition">
-<span class="number">10.21</span>Superscript and subscript (M)
+<span class="number">11.21</span>Superscript and subscript (M)
 </h2>
 <p>To produce superscript like the 3 in 5^3^ = 125, surround it with carets like <code>5^3^ = 125</code>.</p>
 <div class="example" id="example-685">
@@ -20125,7 +20230,7 @@ stuff
 </div>
 <div class="extension">
 <h2 id="strikethrough-gfm-" class="definition">
-<span class="number">10.22</span>Strikethrough (GFM)
+<span class="number">11.22</span>Strikethrough (GFM)
 </h2>
 <p>Markua enables the <code>strikethrough</code> extension, where an additional emphasis type is
 available.</p>
@@ -20164,7 +20269,7 @@ new<span class="space"> </span>paragraph~~.
 </div>
 <div class="extension">
 <h2 id="index-entries-m-" class="definition">
-<span class="number">10.23</span>Index entries (M)
+<span class="number">11.23</span>Index entries (M)
 </h2>
 <p>Markua supports adding index entries via the attribute list syntax. Index
 entries let authors or indexers produce professional-looking indexes in
@@ -20173,7 +20278,7 @@ Markua books.</p>
 attribute list syntax. In fact, index entries can just be added as part of a
 larger attribute list.</p>
 <h3 id="how-to-insert-an-index-entry" class="definition">
-<span class="number">10.23.1</span>How to Insert an Index Entry
+<span class="number">11.23.1</span>How to Insert an Index Entry
 </h3>
 <p>To insert an index entry, you need to <strong>attach it</strong> to a block or span element.</p>
 <p><strong>You MUST attach an index entry to something, e.g. <code>a word{i: &quot;an index entry&quot;}</code>.
@@ -20200,7 +20305,7 @@ a block:</p>
 I just came to say hello, hello, hello, hello
 </code></pre>
 <h3 id="index-entry-format" class="definition">
-<span class="number">10.23.2</span>Index Entry Format
+<span class="number">11.23.2</span>Index Entry Format
 </h3>
 <p>The actual syntax of what the value of an index entry looks like is <a href="https://en.wikibooks.org/wiki/LaTeX/Indexing">inspired
 by LaTeX</a>.</p>
@@ -20287,14 +20392,14 @@ as an attempt at creating a sub-entry. (This actually got me, when I tried to
 reference <em>Hello! Flex 4</em>, one of my books. To do this, I would have to write
 the entry as <code>{i: &quot;*Hello\! Flex 4*}</code> not as <code>{i: &quot;*Hello! Flex 4*}</code>.</p>
 <h3 id="index-output-format" class="definition">
-<span class="number">10.23.3</span>Index Output Format
+<span class="number">11.23.3</span>Index Output Format
 </h3>
 <p>Markua does not specify the format of the HTML output of the actual index itself,
 to maximize implementation flexibility.</p>
 </div>
 <div class="extension">
 <h2 id="syntactic-sugar-list-m-" class="definition">
-<span class="number">10.24</span>Syntactic sugar list (M)
+<span class="number">11.24</span>Syntactic sugar list (M)
 </h2>
 <p>Markua has a handful of syntactic sugar that it relies on to make life nicer for
 authors. Here’s a helpful summary list of the different syntactic sugar elements
@@ -20320,7 +20425,7 @@ a <code>{class: continued-para}</code></p>
 : <code>{format: text}</code></p>
 </div>
 <h2 id="textual-content" class="definition">
-<span class="number">10.25</span>Textual content
+<span class="number">11.25</span>Textual content
 </h2>
 <p>Any characters not given an interpretation by the above rules will
 be parsed as plain textual content.</p>

--- a/spec.txt
+++ b/spec.txt
@@ -1,8 +1,8 @@
 ---
 title: Markua Spec
 author: '*This formal specification of Markua was developed at [Leanpub](https://leanpub.com), is written by Peter Armstrong, is based on the CommonMark Spec (version 0.31.2) by John MacFarlane, and is licensed under the Creative Commons license CC-BY-SA 4.0.*<br/><br/><hr/><br/>NOTE: If you are a Leanpub author, there are two different versions of Markua used on Leanpub. <strong>The default version of Markua for books on Leanpub is Markua 0.30, which is documented in this specification, and which is currently in beta on Leanpub.</strong> The default version of Markua for courses on Leanpub is still Markua 0.10, which is documented in [The Markua Manual](https://leanpub.com/markua/read). (You can still use Markua 0.10 and Leanpub Flavoured Markdown for books on Leanpub, of course.)<br/><br/><hr/><br/>'
-version: '0.31.46'
-date: '2026-06-09'
+version: '0.31.47'
+date: '2026-06-17'
 license: '[CC-BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/)'
 ...
 
@@ -3224,6 +3224,7 @@ the defaults are in one list. These defaults are listed below.
   default-random-question-order: false
   default-table-column-spacing: 6pt
   figure-classes: all
+  include-exercises-in-book: false
   include-page-numbers-in-references: true
   italicize-underlines: true
   lang: eng
@@ -3316,6 +3317,14 @@ of their `class` attribute. An example of this setting is:
 figures are listed, either grouped by their class or together in one big list,
 is controlled by the `list-figures` setting. Note that the numbering of figures
 is controlled by the `number-figures` setting.
+
+`include-exercises-in-book`
+: `true` or `false`. The default value is `false`. Quizzes and exercises are
+intrinsically course content, so by default they are dropped from book outputs
+(PDF, EPUB, etc.) and kept only in course outputs. If you are writing a workbook,
+study guide or instructor manual and want quizzes and exercises to appear in the
+book output as well, set this to `true`. This setting is discussed in the
+[section on sharing content between books and courses](#sharing-content-between-books-and-courses-m-).
 
 `include-page-numbers-in-references`
 : `true` or `false`. The default value is `true`. When a smart crosslink to a
@@ -12398,6 +12407,118 @@ book or course again. However, fixing the consequences of a quiz being
 administered to hundreds--or thousands, or tens of thousands--of people with an
 incorrect number of questions, or with questions incorrectly used as alternates
 for each other, would be much more difficult.
+
+</div>
+
+
+
+<div class="extension">
+
+# Sharing content between books and courses (M)
+
+As discussed in the chapter on quizzes and exercises, a single Markua document
+can be generated both as a book and as a course. Most of the prose is shared
+between the two, but quite often a particular section belongs to only one of
+them. For example, a course might contain a "watch the video, then answer the
+quiz" introduction that makes no sense in the printed book, while the book might
+contain a "since you can't click anything on paper, here is the full transcript"
+passage that is redundant in the course.
+
+Markua provides three constructs for this: two block-level (`{book}` and
+`{course}`), and one inline (the `only` span attribute). It also has an implicit
+rule that quizzes and exercises are course-only by default.
+
+Whenever this section refers to the "target", it means whether the Markua
+Processor is currently generating a book (the PDF, EPUB and equivalent web
+outputs) or a course. The same source document produces both; these constructs
+simply let you gate content on which one is being generated.
+
+## The book and course blocks (M)
+
+The `{book}` and `{course}` block syntaxes are similar to the syntaxes for
+asides and blurbs:
+
+1. By wrapping the content in `{book}` ... `{/book}`, for content which should
+   be included only in book outputs.
+2. By wrapping the content in `{course}` ... `{/course}`, for content which
+   should be included only in course outputs.
+
+When the target is a book, the content inside a `{book}` block is included
+exactly as if the `{book}` and `{/book}` wrapper were not there, and any
+`{course}` blocks are dropped entirely. When the target is a course, the
+reverse happens: `{course}` blocks are unwrapped and `{book}` blocks are
+dropped.
+
+A `{book}` or `{course}` block can contain any Markua content, including
+multiple paragraphs, headings, figures, asides, quizzes and so on.
+
+Here is an example which uses both:
+
+~~~
+This paragraph is shared, so it appears in both the book and the course.
+
+{book}
+Since you are reading this on paper, here is the full transcript of the video.
+{/book}
+
+{course}
+Watch the video above, then complete the quiz that follows.
+{/course}
+
+This closing paragraph is also shared.
+~~~
+
+When this document is generated as a book, the reader sees the shared paragraph,
+the transcript paragraph, and the closing paragraph. When it is generated as a
+course, the reader sees the shared paragraph, the "watch the video" paragraph,
+and the closing paragraph.
+
+## The only span attribute (M)
+
+For inline content which is too small to justify a block, you can instead add an
+`only` attribute to a [span](#span-attribute-lists). The value is the target
+that the span should be included for: either `book` or `course`.
+
+~~~
+The next release ships [in print on June 1st]{only: book}[as twelve video
+lessons]{only: course}.
+~~~
+
+When the target is a book, a span with `only: book` is kept (with the `only`
+attribute removed, so downstream output never sees it) and a span with
+`only: course` is dropped. When the target is a course, the reverse happens.
+
+The value may also be a comma-separated list, for the rare case where you want
+to be explicit that a span belongs to more than one target:
+
+~~~
+This applies [to both formats]{only: book, course}.
+~~~
+
+There is deliberately no `only: all` value: the absence of an `only` attribute
+already means "include everywhere", so `only: book, course` is only ever needed
+when you want to be explicit.
+
+## Quizzes and exercises are course-only by default (M)
+
+Quizzes and exercises (discussed [earlier](#quizzes-and-exercises-m-)) are
+intrinsically course content. Because of this, a `{quiz}` or `{exercise}` block
+is treated as though it were wrapped in a `{course}` block: it is included in
+course outputs and dropped from book outputs by default. You do not need to wrap
+your quizzes and exercises in `{course}` blocks to get this behavior; it is
+implicit.
+
+Sometimes, though, you do want quizzes and exercises in the book output: for
+example, when producing a workbook, a study guide, or an instructor manual. In
+that case, set the `include-exercises-in-book` document setting to `true`:
+
+~~~
+{include-exercises-in-book: true}
+~~~
+
+With this setting, `{quiz}` and `{exercise}` blocks are kept in book outputs as
+well as course outputs. This document setting is also listed in the
+[section on standard document settings](#the-standard-document-settings-m-).
 
 </div>
 


### PR DESCRIPTION
Documents the new shared/exclusive content constructs from [rubosstech/leanpub#5788](https://github.com/rubosstech/leanpub/pull/5788), which add first-class Markua-level support for gating content between book and course outputs.

## What is added to the spec

New section **Sharing content between books and courses (M)** (after *Quizzes and exercises*), covering:

| Construct | Scope | Meaning |
|---|---|---|
| `{book} ... {/book}` | Block | Included only in book outputs |
| `{course} ... {/course}` | Block | Included only in course outputs |
| `[text]{only: book}` / `[text]{only: course}` | Span | Included only for the matching target |

Plus the implicit rule that **`{quiz}` / `{exercise}` blocks are course-only by default**, with the new `include-exercises-in-book: true` document setting to opt them back into book output (for workbooks, study guides, instructor manuals).

## Other changes

- Added `include-exercises-in-book` (default `false`) to the standard document settings list and defaults block.
- Bumped spec to **0.31.47 (2026-06-17)** and regenerated `spec.html` via `build.sh`.

Design choices mirror the source PR: `only:` (not `include:`), no `only: all` (absence already means "everywhere"), comma-separated `only: book, course` for the explicit case, and implicit course-only quizzes/exercises.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
