### PR TITLE
Add Mermaid diagrams; make SVG default to type image (0.31.48)

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -114,7 +114,7 @@ $(document).ready(function() {
 </head>
 <body>
 <h1 class="title">Markua Spec</h1>
-<div class="version">Version 0.31.47 (2026-06-17)</div>
+<div class="version">Version 0.31.48 (2026-06-30)</div>
 <div class="authors">
     <span class="author"><em>This formal specification of Markua was developed at <a href="https://leanpub.com">Leanpub</a>, is written by Peter Armstrong, is based on the CommonMark Spec (version 0.31.2) by John MacFarlane, and is licensed under the Creative Commons license CC-BY-SA 4.0.</em><br/><br/><hr/><br/>NOTE: If you are a Leanpub author, there are two different versions of Markua used on Leanpub. <strong>The default version of Markua for books on Leanpub is Markua 0.30, which is documented in this specification, and which is currently in beta on Leanpub.</strong> The default version of Markua for courses on Leanpub is still Markua 0.10, which is documented in <a href="https://leanpub.com/markua/read">The Markua Manual</a>. (You can still use Markua 0.10 and Leanpub Flavoured Markdown for books on Leanpub, of course.)<br/><br/><hr/><br/></span>
 </div>
@@ -266,23 +266,24 @@ $(document).ready(function() {
 <li><a href="#images"><span class="number">11.6</span>Images</a></li>
 <li><a href="#image-resource-attributes-m-"><span class="number">11.7</span>Image resource attributes (M)</a></li>
 <li><a href="#inline-svg-images-m-"><span class="number">11.8</span>Inline SVG images (M)</a></li>
-<li><a href="#image-locations-and-embedding-m-"><span class="number">11.9</span>Image locations and embedding (M)</a></li>
-<li><a href="#video-resources-m-"><span class="number">11.10</span>Video resources (M)</a></li>
-<li><a href="#iframe-resources-m-"><span class="number">11.11</span>IFrame resources (M)</a></li>
-<li><a href="#audio-resources-m-"><span class="number">11.12</span>Audio resources (M)</a></li>
-<li><a href="#math-resources-m-"><span class="number">11.13</span>Math resources (M)</a></li>
-<li><a href="#autolinks"><span class="number">11.14</span>Autolinks</a></li>
-<li><a href="#no-raw-html-m-"><span class="number">11.15</span>No raw HTML (M)</a></li>
-<li><a href="#hard-line-breaks"><span class="number">11.16</span>Hard line breaks</a></li>
-<li><a href="#soft-line-breaks"><span class="number">11.17</span>Soft line breaks</a></li>
-<li><a href="#character-substitutions-m-"><span class="number">11.18</span>Character substitutions (M)</a></li>
-<li><a href="#footnotes-and-endnotes-m-"><span class="number">11.19</span>Footnotes and endnotes (M)</a></li>
-<li><a href="#underline-m-"><span class="number">11.20</span>Underline (M)</a></li>
-<li><a href="#superscript-and-subscript-m-"><span class="number">11.21</span>Superscript and subscript (M)</a></li>
-<li><a href="#strikethrough-gfm-"><span class="number">11.22</span>Strikethrough (GFM)</a></li>
-<li><a href="#index-entries-m-"><span class="number">11.23</span>Index entries (M)</a></li>
-<li><a href="#syntactic-sugar-list-m-"><span class="number">11.24</span>Syntactic sugar list (M)</a></li>
-<li><a href="#textual-content"><span class="number">11.25</span>Textual content</a></li>
+<li><a href="#mermaid-diagrams-m-"><span class="number">11.9</span>Mermaid diagrams (M)</a></li>
+<li><a href="#image-locations-and-embedding-m-"><span class="number">11.10</span>Image locations and embedding (M)</a></li>
+<li><a href="#video-resources-m-"><span class="number">11.11</span>Video resources (M)</a></li>
+<li><a href="#iframe-resources-m-"><span class="number">11.12</span>IFrame resources (M)</a></li>
+<li><a href="#audio-resources-m-"><span class="number">11.13</span>Audio resources (M)</a></li>
+<li><a href="#math-resources-m-"><span class="number">11.14</span>Math resources (M)</a></li>
+<li><a href="#autolinks"><span class="number">11.15</span>Autolinks</a></li>
+<li><a href="#no-raw-html-m-"><span class="number">11.16</span>No raw HTML (M)</a></li>
+<li><a href="#hard-line-breaks"><span class="number">11.17</span>Hard line breaks</a></li>
+<li><a href="#soft-line-breaks"><span class="number">11.18</span>Soft line breaks</a></li>
+<li><a href="#character-substitutions-m-"><span class="number">11.19</span>Character substitutions (M)</a></li>
+<li><a href="#footnotes-and-endnotes-m-"><span class="number">11.20</span>Footnotes and endnotes (M)</a></li>
+<li><a href="#underline-m-"><span class="number">11.21</span>Underline (M)</a></li>
+<li><a href="#superscript-and-subscript-m-"><span class="number">11.22</span>Superscript and subscript (M)</a></li>
+<li><a href="#strikethrough-gfm-"><span class="number">11.23</span>Strikethrough (GFM)</a></li>
+<li><a href="#index-entries-m-"><span class="number">11.24</span>Index entries (M)</a></li>
+<li><a href="#syntactic-sugar-list-m-"><span class="number">11.25</span>Syntactic sugar list (M)</a></li>
+<li><a href="#textual-content"><span class="number">11.26</span>Textual content</a></li>
 </ul>
 </li>
 <li><a href="#appendix-a-parsing-strategy">Appendix: A parsing strategy</a>
@@ -6614,6 +6615,12 @@ three backticks.</li>
 </ol>
 <p>Note that the default format can be overridden by specifying it via an attribute
 list, or after the three backticks in syntactic sugar.</p>
+<p>There are two formats which, when specified after the three backticks, produce a
+resource of <code>type</code> <code>image</code> rather than <code>type</code> <code>code</code>: the <code>svg</code> and <code>mermaid</code>
+formats. A fenced code block of <code>```svg</code> or <code>```mermaid</code> is rendered as
+an image by default. To show the source as code instead, override the type with
+<code>{type: code}</code>. This is discussed in the Inline SVG images and Mermaid diagrams
+sections.</p>
 <h3 id="supported-attributes-for-code" class="definition">
 <span class="number">7.6.1</span>Supported Attributes for Code
 </h3>
@@ -18449,6 +18456,17 @@ choose them by default:</p>
 : SVG image - <code>.svg</code></p>
 <p><code>svgz</code>
 : SVG image (zipped) - <code>.svgz</code></p>
+<p><code>mermaid</code>
+: Mermaid diagram - <code>.mmd</code> or <code>.mermaid</code></p>
+<p>Two of these formats are special: <code>svg</code> and <code>mermaid</code>. Unlike a binary image
+format such as PNG or JPEG, an SVG image and a Mermaid diagram are each just
+text, so they can be contained inline in the text of a Markua document. And,
+unlike any other format that can appear after a code fence (such as <code>ruby</code> or
+<code>xml</code>, which produce a resource of <code>type</code> <code>code</code>), <code>svg</code> and <code>mermaid</code> each
+default to a <code>type</code> of <code>image</code> rather than <code>code</code>. In other words, a fenced
+code block of <code>```svg</code> or <code>```mermaid</code> is rendered as an image by
+default, rather than displayed as source. This is discussed in the Inline SVG
+images and Mermaid diagrams sections below.</p>
 <p>Markua uses the image syntax for all resource types. Markua also reinterprets
 images as being a resource. This is important for the following reason:</p>
 <p>Resources can have attribute lists.</p>
@@ -18595,7 +18613,16 @@ or any type of audio or video file–these can only be local or web resources.</
 <p>To add an inline SVG image, you create a fenced code block, and then you
 indicate that instead of code, you are inserting a resource of type image
 and of format SVG.</p>
-<p>There are two ways to do this.  Here’s the verbose way:</p>
+<p>The most natural way is to put <code>svg</code> directly after the opening code fence.
+Because the <code>svg</code> format defaults to a <code>type</code> of <code>image</code>, this is rendered as
+an image, not displayed as the XML source of the SVG image:</p>
+<pre><code>```svg
+&lt;svg width=&quot;20&quot; height=&quot;20&quot;&gt;
+  &lt;circle cx=&quot;10&quot; cy=&quot;10&quot; r=&quot;9&quot; fill=&quot;blue&quot;/&gt;
+&lt;/svg&gt;
+```
+</code></pre>
+<p>You can also be verbose and specify both the <code>type</code> and the <code>format</code>:</p>
 <pre><code>{type: image, format: svg}
 ```
 &lt;svg width=&quot;20&quot; height=&quot;20&quot;&gt;
@@ -18603,7 +18630,7 @@ and of format SVG.</p>
 &lt;/svg&gt;
 ```
 </code></pre>
-<p>Here’s the syntactic sugar way:</p>
+<p>There is also a syntactic sugar way, using a <code>!</code> after the opening code fence:</p>
 <pre><code>```!
 &lt;svg width=&quot;20&quot; height=&quot;20&quot;&gt;
   &lt;circle cx=&quot;10&quot; cy=&quot;10&quot; r=&quot;9&quot; fill=&quot;blue&quot;/&gt;
@@ -18615,13 +18642,13 @@ and that it should be rendered as an image, not displayed as the XML source of
 the SVG image.</p>
 <p>Inline SVG images support all the normal image resource attributes:</p>
 <pre><code>{alt: &quot;a blue circle&quot;, title: &quot;Earth From Space (Simplified)&quot;}
-```!
+```svg
 &lt;svg width=&quot;20&quot; height=&quot;20&quot;&gt;
   &lt;circle cx=&quot;10&quot; cy=&quot;10&quot; r=&quot;9&quot; fill=&quot;blue&quot;/&gt;
 &lt;/svg&gt;
 ```
 </code></pre>
-<p>You can use them with the verbose way as well:</p>
+<p>You can use them with any of the ways above:</p>
 <pre><code>{type: image, format: svg, alt: &quot;foo&quot;, title: &quot;bar&quot;}
 ```
 &lt;svg width=&quot;20&quot; height=&quot;20&quot;&gt;
@@ -18635,17 +18662,11 @@ you are really doing is creating a code resource. This is discussed below.</p>
 <span class="number">11.8.1</span>Writing about SVG
 </h3>
 <p>If you want to write about the SVG format, and show the actual SVG source
-(instead of the image produced), it needs to be of a <code>format</code> of <code>code</code>, not
-<code>image</code>.</p>
-<p>Now, you can just be lazy and not provide <code>format</code> or <code>type</code> attributes at all,
-since guessing when neither is present always produces a type of <code>code</code>.</p>
-<pre><code>```
-&lt;svg width=&quot;20&quot; height=&quot;20&quot;&gt;
-  &lt;circle cx=&quot;10&quot; cy=&quot;10&quot; r=&quot;9&quot; fill=&quot;blue&quot;/&gt;
-&lt;/svg&gt;
-```
-</code></pre>
-<p>However, you can also just specify both, either this way…</p>
+(instead of the image produced), you need a <code>type</code> of <code>code</code> rather than the
+default <code>type</code> of <code>image</code>.</p>
+<p>Since the <code>svg</code> format defaults to a <code>type</code> of <code>image</code>, a bare <code>```svg</code>
+renders as an image. To show the source instead, override the type with
+<code>{type: code}</code>, just as you would for a Mermaid diagram:</p>
 <pre><code>{type: code}
 ```svg
 &lt;svg width=&quot;20&quot; height=&quot;20&quot;&gt;
@@ -18653,7 +18674,7 @@ since guessing when neither is present always produces a type of <code>code</cod
 &lt;/svg&gt;
 ```
 </code></pre>
-<p>…or this way:</p>
+<p>This is the same as specifying both attributes:</p>
 <pre><code>{type: code, format: svg}
 ```
 &lt;svg width=&quot;20&quot; height=&quot;20&quot;&gt;
@@ -18661,9 +18682,9 @@ since guessing when neither is present always produces a type of <code>code</cod
 &lt;/svg&gt;
 ```
 </code></pre>
-<p>…or this way:</p>
-<pre><code>
-```svg
+<p>Alternatively, you can be lazy and not provide <code>format</code> or <code>type</code> attributes at
+all, since guessing when neither is present always produces a type of <code>code</code>:</p>
+<pre><code>```
 &lt;svg width=&quot;20&quot; height=&quot;20&quot;&gt;
   &lt;circle cx=&quot;10&quot; cy=&quot;10&quot; r=&quot;9&quot; fill=&quot;blue&quot;/&gt;
 &lt;/svg&gt;
@@ -18692,8 +18713,89 @@ since guessing when neither is present always produces a type of <code>code</cod
 </code></pre>
 </div>
 <div class="extension">
+<h2 id="mermaid-diagrams-m-" class="definition">
+<span class="number">11.9</span>Mermaid diagrams (M)
+</h2>
+<p><a href="https://mermaid.js.org">Mermaid</a> is a text-based syntax for describing
+diagrams, such as flowcharts, sequence diagrams and Gantt charts. Like an SVG
+image, a Mermaid diagram is just text, so it can be contained inline in the text
+of a Markua document. (This is not true for binary resources like PNG or JPEG
+images, which can only be local or web resources.)</p>
+<p>A Mermaid diagram is an image resource whose <code>format</code> is <code>mermaid</code>. By default,
+a resource with a <code>format</code> of <code>mermaid</code> has a <code>type</code> of <code>image</code>: the Markua
+Processor renders the Mermaid source into a diagram, rather than displaying the
+source as code.</p>
+<p>In this respect, <code>mermaid</code> behaves just like the <code>svg</code> format. These are the
+only two formats that, when placed after a code fence, produce a resource of
+<code>type</code> <code>image</code> by default. For every other format (such as <code>ruby</code> or <code>xml</code>), a
+bare fenced code block produces a resource of <code>type</code> <code>code</code>, and the format is
+only used to select syntax highlighting. For <code>svg</code> and <code>mermaid</code>, the default
+<code>type</code> is <code>image</code>.</p>
+<p>There are several equivalent ways to insert a Mermaid diagram.</p>
+<p>Here’s the verbose way, specifying both the <code>type</code> and the <code>format</code>:</p>
+<pre><code>{type: image, format: mermaid}
+```
+sequenceDiagram
+    Starbuck-&gt;&gt;Apollo: You have a go.
+```
+</code></pre>
+<p>Since a <code>format</code> of <code>mermaid</code> implies a <code>type</code> of <code>image</code>, you can omit the
+<code>type</code> and just specify the <code>format</code>:</p>
+<pre><code>{format: mermaid}
+```
+sequenceDiagram
+    Starbuck-&gt;&gt;Apollo: You have a go.
+```
+</code></pre>
+<p>The most natural way, however, is to put <code>mermaid</code> directly after the opening
+code fence, exactly as you would in other Markdown tools. Because the <code>mermaid</code>
+format defaults to a <code>type</code> of <code>image</code>, this renders as a diagram:</p>
+<pre><code>```mermaid
+sequenceDiagram
+    Starbuck-&gt;&gt;Apollo: You have a go.
+```
+</code></pre>
+<p>This is equivalent to explicitly specifying the <code>type</code>:</p>
+<pre><code>{type: image}
+```mermaid
+sequenceDiagram
+    Starbuck-&gt;&gt;Apollo: You have a go.
+```
+</code></pre>
+<p>Mermaid diagrams support all the normal image resource attributes, such as
+<code>alt</code>, <code>title</code>, <code>width</code>, <code>height</code>, <code>align</code> and <code>float</code>:</p>
+<pre><code>{alt: &quot;a sequence diagram&quot;, title: &quot;The Go Order&quot;, width: 60%}
+```mermaid
+sequenceDiagram
+    Starbuck-&gt;&gt;Apollo: You have a go.
+```
+</code></pre>
+<h3 id="writing-about-mermaid" class="definition">
+<span class="number">11.9.1</span>Writing about Mermaid
+</h3>
+<p>If you want to write about the Mermaid format, and show the actual Mermaid
+source (instead of the diagram produced), you need a <code>type</code> of <code>code</code> rather
+than the default <code>type</code> of <code>image</code>.</p>
+<p>You do this by overriding the <code>type</code> in an attribute list:</p>
+<pre><code>{type: code}
+```mermaid
+sequenceDiagram
+    Starbuck-&gt;&gt;Apollo: You have a go.
+```
+</code></pre>
+<p>This displays the Mermaid source as a code resource (using <code>mermaid</code> for syntax
+highlighting), rather than rendering it as a diagram. This is the same as
+specifying both attributes:</p>
+<pre><code>{type: code, format: mermaid}
+```
+sequenceDiagram
+    Starbuck-&gt;&gt;Apollo: You have a go.
+```
+</code></pre>
+</div>
+<div class="extension">
 <h2 id="image-locations-and-embedding-m-" class="definition">
-<span class="number">11.9</span>Image locations and embedding (M)
+<span class="number">11.10</span>Image locations and embedding (M)
 </h2>
 <p>Note that regardless of the image location, a Markua Processor can handle images
 in the following ways:</p>
@@ -18711,7 +18813,7 @@ GIF, PNG, JPEG, SVG and zipped SVG.</p>
 </div>
 <div class="extension">
 <h2 id="video-resources-m-" class="definition">
-<span class="number">11.10</span>Video resources (M)
+<span class="number">11.11</span>Video resources (M)
 </h2>
 <p>Note that .mp4 is used for MP4 video, not MP4 AAC audio.</p>
 <p>The following are the video resource formats and the file extensions which
@@ -18740,7 +18842,7 @@ work in some Markua Processors, like Leanpub, without specifying either the
 <p>We will discuss the supported and the default attributes for videos, and then
 show examples of videos being inserted for both local and web videos.</p>
 <h3 id="supported-attributes-for-video" class="definition">
-<span class="number">11.10.1</span>Supported Attributes for Video
+<span class="number">11.11.1</span>Supported Attributes for Video
 </h3>
 <p>The following are the supported attributes for video resources, in addition to
 the <code>class</code>, <code>format</code>, <code>title</code> and <code>type</code> attributes which all resources
@@ -18810,7 +18912,7 @@ with images.</p>
 an HTML mapping, please note that a Markua Processor has complete flexibility
 over how it handles the location of video resources and their display.</p>
 <h3 id="local-video" class="definition">
-<span class="number">11.10.2</span>Local Video
+<span class="number">11.11.2</span>Local Video
 </h3>
 <div class="example" id="example-640">
 <div class="examplenum">
@@ -18835,7 +18937,7 @@ Here's<span class="space"> </span>a<span class="space"> </span>paragraph<span cl
 </div>
 </div>
 <h3 id="web-video" class="definition">
-<span class="number">11.10.3</span>Web Video
+<span class="number">11.11.3</span>Web Video
 </h3>
 <div class="example" id="example-641">
 <div class="examplenum">
@@ -18864,7 +18966,7 @@ poster=&quot;https://img.youtube.com/vi/VOCYL-FNbr0/mqdefault.jpg&quot;/&gt;
 </div>
 <div class="extension">
 <h2 id="iframe-resources-m-" class="definition">
-<span class="number">11.11</span>IFrame resources (M)
+<span class="number">11.12</span>IFrame resources (M)
 </h2>
 <p>The syntax to insert an IFrame is almost identical to that is used for video
 resources.</p>
@@ -18876,7 +18978,7 @@ are created in Markua.</p>
 <p>The only resource location which is supported for an IFrame resource is the
 web resource location, for obvious reasons.</p>
 <h3 id="supported-attributes-for-resources" class="definition">
-<span class="number">11.11.1</span>Supported Attributes for <code>iframe</code> Resources
+<span class="number">11.12.1</span>Supported Attributes for <code>iframe</code> Resources
 </h3>
 <p>The following are the supported attributes for IFrame resources, in addition to
 the <code>class</code>, <code>format</code>, <code>title</code> and <code>type</code> attributes which all resources
@@ -18937,7 +19039,7 @@ Here's<span class="space"> </span>a<span class="space"> </span>paragraph<span cl
 </div>
 <div class="extension">
 <h2 id="audio-resources-m-" class="definition">
-<span class="number">11.12</span>Audio resources (M)
+<span class="number">11.13</span>Audio resources (M)
 </h2>
 <p>The following are the audio resource formats and the file extensions which
 choose them by default:</p>
@@ -18975,7 +19077,7 @@ and Ogg Vorbis.</p>
 <p>We will discuss the supported and the default attributes for audio files, and
 then show examples of audio being inserted for both local and web audio files.</p>
 <h3 id="supported-attributes-for-audio" class="definition">
-<span class="number">11.12.1</span>Supported Attributes for Audio
+<span class="number">11.13.1</span>Supported Attributes for Audio
 </h3>
 <p>The following are the supported attributes for audio resources, in addition to
 the <code>class</code>, <code>format</code>, <code>title</code> and <code>type</code> attributes which all resources
@@ -18995,7 +19097,7 @@ this. See the Video resources section above for more information.</p>
 an HTML mapping, please note that a Markua Processor has complete flexibility
 over how it handles the location of video resources and their display.</p>
 <h3 id="local-audio" class="definition">
-<span class="number">11.12.2</span>Local Audio
+<span class="number">11.13.2</span>Local Audio
 </h3>
 <div class="example" id="example-643">
 <div class="examplenum">
@@ -19017,7 +19119,7 @@ over how it handles the location of video resources and their display.</p>
 </div>
 </div>
 <h3 id="web-audio" class="definition">
-<span class="number">11.12.3</span>Web Audio
+<span class="number">11.13.3</span>Web Audio
 </h3>
 <div class="example" id="example-644">
 <div class="examplenum">
@@ -19041,7 +19143,7 @@ over how it handles the location of video resources and their display.</p>
 </div>
 <div class="extension">
 <h2 id="math-resources-m-" class="definition">
-<span class="number">11.13</span>Math resources (M)
+<span class="number">11.14</span>Math resources (M)
 </h2>
 <p>Math can be a local, web or inline resource, just like any other resource, and
 the same resource syntax applies to code as to all other resources.</p>
@@ -19058,7 +19160,7 @@ like transparent SVGs with a dynamic foreground color, or MathJax or MathML.</p>
 </ol>
 <p><strong>Leanpub authors: Note that AsciiMath is currently not implemented in Leanpub.</strong></p>
 <h3 id="math-resource-formats" class="definition">
-<span class="number">11.13.1</span>Math resource formats
+<span class="number">11.14.1</span>Math resource formats
 </h3>
 <p>The following are the math resource formats and the file extensions which
 choose them by default:</p>
@@ -19076,7 +19178,7 @@ display it, then add a <code>{type: code, format: latex}</code> attribute list.<
 <p>Note that the assumption is that AsciiMath will almost always be used as an
 inline resource. So, the <code>.asciimath</code> file extension is deliberately verbose.</p>
 <h3 id="supported-attributes-for-math" class="definition">
-<span class="number">11.13.2</span>Supported Attributes for Math
+<span class="number">11.14.2</span>Supported Attributes for Math
 </h3>
 <p>The following are the supported attribute for math resources, in addition to the
 <code>class</code>, <code>format</code>, <code>title</code> and <code>type</code> attributes which all resources support:</p>
@@ -19094,7 +19196,7 @@ into Markua: <code>latexmath</code> for LaTeX math and <code>asciimath</code> fo
 Markua Processor encounters one of these formats, it must assume the <code>type</code> of
 the resource is <code>math</code>, not <code>code</code>.</p>
 <h3 id="using-bold-and-strikethrough-formatting-with-math" class="definition">
-<span class="number">11.13.3</span>Using bold and strikethrough formatting with math
+<span class="number">11.14.3</span>Using bold and strikethrough formatting with math
 </h3>
 <p>Markua supports formatting math as bold or strikethrough.</p>
 <p>Math can be <code>**bolded**</code> by being wrapped with two asterisks, and can be
@@ -19102,7 +19204,7 @@ formatted in <code>~~strikethrough~~</code> by being wrapped with two tildes. No
 the format of the strikethrough line is controlled by the
 <code>strikethrough-format</code> document setting.</p>
 <h3 id="local-math-resources" class="definition">
-<span class="number">11.13.4</span>Local math resources
+<span class="number">11.14.4</span>Local math resources
 </h3>
 <p>Local math resources can be inserted as a figure.</p>
 <pre><code>Here's a paragraph before the figure.
@@ -19121,7 +19223,7 @@ Here's a paragraph after the figure.
 Here's a paragraph after the figure.
 </code></pre>
 <h3 id="web-math-resources" class="definition">
-<span class="number">11.13.5</span>Web math resources
+<span class="number">11.14.5</span>Web math resources
 </h3>
 <p>This is identical to how local math resources work, including the significance
 of file extensions. The only difference is that the files are on the web.</p>
@@ -19141,14 +19243,14 @@ Here's a paragraph after the figure.
 Here's a paragraph after the figure.
 </code></pre>
 <h3 id="inline-math-resources" class="definition">
-<span class="number">11.13.6</span>Inline math resources
+<span class="number">11.14.6</span>Inline math resources
 </h3>
 <p>Inline math resources are the most flexible way to insert math. They are the only
 way to insert math as a span resource, and the most straightforward way to add
 short math examples as figures. LaTeX math and AsciiMath can be inserted inline
 as a span or figure.</p>
 <h4 id="span" class="definition">
-<span class="number">11.13.6.1</span>Span
+<span class="number">11.14.6.1</span>Span
 </h4>
 <p>Being able to insert a math resource as a span is important, as it lets you write
 things like one of the kinematic equations <code>d = v_i t + \frac{1}{2} a t^2</code>$ inside
@@ -19158,7 +19260,7 @@ an <code>@</code> after the closing backtick for AsciiMath, or an attribute list
 a <code>format</code> of <code>latexmath</code> or <code>asciimath</code>. If none of these is done, the content
 of the backticks is treated as code and is output verbatim as monospaced text.</p>
 <h5 id="latex-math-span" class="definition">
-<span class="number">11.13.6.1.1</span>LaTeX math span
+<span class="number">11.14.6.1.1</span>LaTeX math span
 </h5>
 <p>There is syntactic sugar for LaTeX math which is inserted as a span, using the
 <code>$</code> character after the closing backtick:</p>
@@ -19173,7 +19275,7 @@ sentence.
 inside a sentence.
 </code></pre>
 <h5 id="asciimath-span" class="definition">
-<span class="number">11.13.6.1.2</span>AsciiMath span
+<span class="number">11.14.6.1.2</span>AsciiMath span
 </h5>
 <p><a href="https://asciimath.org/">AsciiMath</a> is a way of producing simple MathML equations,
 using about 1% of the typing. It’s more terse than LaTeX math.</p>
@@ -19188,7 +19290,7 @@ character after the closing backtick:</p>
 inside a sentence.
 </code></pre>
 <h4 id="figure" class="definition">
-<span class="number">11.13.6.2</span>Figure
+<span class="number">11.14.6.2</span>Figure
 </h4>
 <p>LaTeX math and AsciiMath can be inserted inline as a figure.</p>
 <ul>
@@ -19198,7 +19300,7 @@ backticks, or by specifying an attribute list of <code>{format: latexmath}</code
 backticks, or by specifying an attribute list of <code>{format: asciimath}</code>.</li>
 </ul>
 <h5 id="latex-math-figures" class="definition">
-<span class="number">11.13.6.2.1</span>LaTeX math figures
+<span class="number">11.14.6.2.1</span>LaTeX math figures
 </h5>
 <p>Here’s how you do this using LaTeX math…</p>
 <p>Here’s the version with the syntactic sugar for the format after the backticks:</p>
@@ -19239,7 +19341,7 @@ Here's a paragraph after the figure.
 Here's a paragraph after the figure.
 </code></pre>
 <h5 id="asciimath-figures" class="definition">
-<span class="number">11.13.6.2.2</span>AsciiMath figures
+<span class="number">11.14.6.2.2</span>AsciiMath figures
 </h5>
 <p>Here’s how you do this using AsciiMath…</p>
 <p>Here’s the version with the syntactic sugar for the format after the backticks:</p>
@@ -19277,7 +19379,7 @@ text, what you are really doing is creating a code resource. This is essentially
 identical to what was shown earlier in writing about SVG images. It’s also shown
 below.</p>
 <h3 id="writing-about-math" class="definition">
-<span class="number">11.13.7</span>Writing about Math
+<span class="number">11.14.7</span>Writing about Math
 </h3>
 <p>If you want to write about math, and show the actual code (instead of the
 formatted output), it needs to be of a <code>format</code> of <code>code</code>, not <code>math</code>.</p>
@@ -19338,7 +19440,7 @@ abs(sum_(i=1)^n a_i b_i) &lt;= (sum_(i=1)^n a_i^2)^(1/2) (sum_(i=1)^n b_i^2)^(1/
 </code></pre>
 </div>
 <h2 id="autolinks" class="definition">
-<span class="number">11.14</span>Autolinks
+<span class="number">11.15</span>Autolinks
 </h2>
 <p><a id="autolink" href="#autolink" class="definition">Autolink</a>s are absolute URIs and email addresses inside
 <code>&lt;</code> and <code>&gt;</code>. They are parsed as links, with the URL or email address
@@ -19627,7 +19729,7 @@ spec</a>:</p>
 </div>
 <div class="extension">
 <h2 id="no-raw-html-m-" class="definition">
-<span class="number">11.15</span>No raw HTML (M)
+<span class="number">11.16</span>No raw HTML (M)
 </h2>
 <p>As <a href="#markua-s-one-key-subtraction-from-markdown-raw-html-is-removed-m-">discussed</a>,
 Markua does not support raw HTML. <strong>All raw HTML is removed</strong>. As a side-effect,
@@ -19635,7 +19737,7 @@ this means HTML comments can still be used, since they (like all HTML) will be
 removed from the output.</p>
 </div>
 <h2 id="hard-line-breaks" class="definition">
-<span class="number">11.16</span>Hard line breaks
+<span class="number">11.17</span>Hard line breaks
 </h2>
 <p>A line ending (not in a code span or HTML tag) that is preceded
 by two or more spaces and does not occur at the end of a block
@@ -19868,7 +19970,7 @@ other block element:</p>
 </div>
 </div>
 <h2 id="soft-line-breaks" class="definition">
-<span class="number">11.17</span>Soft line breaks
+<span class="number">11.18</span>Soft line breaks
 </h2>
 <p>A regular line ending (not in a code span or HTML tag) that is not
 preceded by two or more spaces or a backslash is parsed as a
@@ -19913,7 +20015,7 @@ line ending or as a space.</p>
 as hard line breaks.</p>
 <div class="extension">
 <h2 id="character-substitutions-m-" class="definition">
-<span class="number">11.18</span>Character substitutions (M)
+<span class="number">11.19</span>Character substitutions (M)
 </h2>
 <p>Markua documents can be written in UTF-8, so to produce any Unicode character, it
 is possible to just use the proper Unicode characters. However, in certain cases,
@@ -19939,7 +20041,7 @@ paragraph).</p>
 : To produce a horizontal ellipsis (…), you can just type <code>...</code>. You can also use
 the proper Unicode character, U+2026, of course.</p>
 <h3 id="optional-automatic-curly-quotes-outside-of-code-blocks-and-spans" class="definition">
-<span class="number">11.18.1</span>Optional Automatic Curly Quotes Outside of Code Blocks and Spans
+<span class="number">11.19.1</span>Optional Automatic Curly Quotes Outside of Code Blocks and Spans
 </h3>
 <p>A Markua Processor may replace the <code>&quot;</code> character with the appropriate “curly
 quote” at its discretion. This lets <code>&quot;typography&quot;</code> become <code>“typography”</code>, and
@@ -19956,11 +20058,11 @@ straight in a code span either.)</p>
 </div>
 <div class="extension">
 <h2 id="footnotes-and-endnotes-m-" class="definition">
-<span class="number">11.19</span>Footnotes and endnotes (M)
+<span class="number">11.20</span>Footnotes and endnotes (M)
 </h2>
 <p>Books often have footnotes and endnotes. So, Markua has them too.</p>
 <h3 id="footnotes" class="definition">
-<span class="number">11.19.1</span>Footnotes
+<span class="number">11.20.1</span>Footnotes
 </h3>
 <p>To add a footnote, you insert a footnote tag using square brackets, a caret and
 the tag, like this:</p>
@@ -19990,7 +20092,7 @@ should output them <em>somewhere</em>, but the details are not specified. This i
 deliberate, in order to maximize implementation flexibility for Markua
 Processors.</p>
 <h3 id="endnotes" class="definition">
-<span class="number">11.19.2</span>Endnotes
+<span class="number">11.20.2</span>Endnotes
 </h3>
 <p>Sometimes endnotes are used instead of footnotes, but other times, these are in
 addition to footnotes. So, it makes sense for Markua to define separate syntaxes
@@ -20016,7 +20118,7 @@ should output them <em>somewhere</em>, but the details are not specified. This i
 deliberate, in order to maximize implementation flexibility for Markua
 Processors.</p>
 <h3 id="single-reference-to-footnotes-and-endnotes" class="definition">
-<span class="number">11.19.3</span>Single reference to footnotes and endnotes
+<span class="number">11.20.3</span>Single reference to footnotes and endnotes
 </h3>
 <p>You can only refer to a footnote or endnote once. You can’t define a footnote or
 endnote in one place and refer to it multiple times in the same Markua document.
@@ -20025,7 +20127,7 @@ Markua document, the best approach is to put it in a section (or sub-section,
 sub-sub-section, etc.) or aside and refer to it from multiple places using a
 <a href="#crosslinks">crosslink</a>.</p>
 <h3 id="footnote-and-endnote-support-is-required-for-paragraphs-only" class="definition">
-<span class="number">11.19.4</span>Footnote and endnote support is required for paragraphs only
+<span class="number">11.20.4</span>Footnote and endnote support is required for paragraphs only
 </h3>
 <p>A Markua Processor must support footnote and endnote references inserted in
 normal paragraph content. However, that’s it.</p>
@@ -20044,7 +20146,7 @@ only supports inserting footnotes or endnotes in normal paragraph content.</p>
 </div>
 <div class="extension">
 <h2 id="underline-m-" class="definition">
-<span class="number">11.20</span>Underline (M)
+<span class="number">11.21</span>Underline (M)
 </h2>
 <p>In Markdown as defined by John Gruber, and in CommonMark and GFM,
 <code>*one asterisk*</code> and <code>_one underscore_</code> both produce <em>italics</em>, and there is no
@@ -20197,7 +20299,7 @@ stuff
 </div>
 <div class="extension">
 <h2 id="superscript-and-subscript-m-" class="definition">
-<span class="number">11.21</span>Superscript and subscript (M)
+<span class="number">11.22</span>Superscript and subscript (M)
 </h2>
 <p>To produce superscript like the 3 in 5^3^ = 125, surround it with carets like <code>5^3^ = 125</code>.</p>
 <div class="example" id="example-685">
@@ -20230,7 +20332,7 @@ stuff
 </div>
 <div class="extension">
 <h2 id="strikethrough-gfm-" class="definition">
-<span class="number">11.22</span>Strikethrough (GFM)
+<span class="number">11.23</span>Strikethrough (GFM)
 </h2>
 <p>Markua enables the <code>strikethrough</code> extension, where an additional emphasis type is
 available.</p>
@@ -20269,7 +20371,7 @@ new<span class="space"> </span>paragraph~~.
 </div>
 <div class="extension">
 <h2 id="index-entries-m-" class="definition">
-<span class="number">11.23</span>Index entries (M)
+<span class="number">11.24</span>Index entries (M)
 </h2>
 <p>Markua supports adding index entries via the attribute list syntax. Index
 entries let authors or indexers produce professional-looking indexes in
@@ -20278,7 +20380,7 @@ Markua books.</p>
 attribute list syntax. In fact, index entries can just be added as part of a
 larger attribute list.</p>
 <h3 id="how-to-insert-an-index-entry" class="definition">
-<span class="number">11.23.1</span>How to Insert an Index Entry
+<span class="number">11.24.1</span>How to Insert an Index Entry
 </h3>
 <p>To insert an index entry, you need to <strong>attach it</strong> to a block or span element.</p>
 <p><strong>You MUST attach an index entry to something, e.g. <code>a word{i: &quot;an index entry&quot;}</code>.
@@ -20305,7 +20407,7 @@ a block:</p>
 I just came to say hello, hello, hello, hello
 </code></pre>
 <h3 id="index-entry-format" class="definition">
-<span class="number">11.23.2</span>Index Entry Format
+<span class="number">11.24.2</span>Index Entry Format
 </h3>
 <p>The actual syntax of what the value of an index entry looks like is <a href="https://en.wikibooks.org/wiki/LaTeX/Indexing">inspired
 by LaTeX</a>.</p>
@@ -20392,14 +20494,14 @@ as an attempt at creating a sub-entry. (This actually got me, when I tried to
 reference <em>Hello! Flex 4</em>, one of my books. To do this, I would have to write
 the entry as <code>{i: &quot;*Hello\! Flex 4*}</code> not as <code>{i: &quot;*Hello! Flex 4*}</code>.</p>
 <h3 id="index-output-format" class="definition">
-<span class="number">11.23.3</span>Index Output Format
+<span class="number">11.24.3</span>Index Output Format
 </h3>
 <p>Markua does not specify the format of the HTML output of the actual index itself,
 to maximize implementation flexibility.</p>
 </div>
 <div class="extension">
 <h2 id="syntactic-sugar-list-m-" class="definition">
-<span class="number">11.24</span>Syntactic sugar list (M)
+<span class="number">11.25</span>Syntactic sugar list (M)
 </h2>
 <p>Markua has a handful of syntactic sugar that it relies on to make life nicer for
 authors. Here’s a helpful summary list of the different syntactic sugar elements
@@ -20425,7 +20527,7 @@ a <code>{class: continued-para}</code></p>
 : <code>{format: text}</code></p>
 </div>
 <h2 id="textual-content" class="definition">
-<span class="number">11.25</span>Textual content
+<span class="number">11.26</span>Textual content
 </h2>
 <p>Any characters not given an interpretation by the above rules will
 be parsed as plain textual content.</p>

--- a/spec.txt
+++ b/spec.txt
@@ -1,8 +1,8 @@
 ---
 title: Markua Spec
 author: '*This formal specification of Markua was developed at [Leanpub](https://leanpub.com), is written by Peter Armstrong, is based on the CommonMark Spec (version 0.31.2) by John MacFarlane, and is licensed under the Creative Commons license CC-BY-SA 4.0.*<br/><br/><hr/><br/>NOTE: If you are a Leanpub author, there are two different versions of Markua used on Leanpub. <strong>The default version of Markua for books on Leanpub is Markua 0.30, which is documented in this specification, and which is currently in beta on Leanpub.</strong> The default version of Markua for courses on Leanpub is still Markua 0.10, which is documented in [The Markua Manual](https://leanpub.com/markua/read). (You can still use Markua 0.10 and Leanpub Flavoured Markdown for books on Leanpub, of course.)<br/><br/><hr/><br/>'
-version: '0.31.47'
-date: '2026-06-17'
+version: '0.31.48'
+date: '2026-06-30'
 license: '[CC-BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/)'
 ...
 
@@ -6015,6 +6015,13 @@ The default value of the format attribute for code is complex:
 
 Note that the default format can be overridden by specifying it via an attribute
 list, or after the three backticks in syntactic sugar.
+
+There are two formats which, when specified after the three backticks, produce a
+resource of `type` `image` rather than `type` `code`: the `svg` and `mermaid`
+formats. A fenced code block of `` ```svg `` or `` ```mermaid `` is rendered as
+an image by default. To show the source as code instead, override the type with
+`{type: code}`. This is discussed in the Inline SVG images and Mermaid diagrams
+sections.
 
 ### Supported Attributes for Code
 
@@ -15778,6 +15785,19 @@ choose them by default:
 `svgz`
 : SVG image (zipped) - `.svgz`
 
+`mermaid`
+: Mermaid diagram - `.mmd` or `.mermaid`
+
+Two of these formats are special: `svg` and `mermaid`. Unlike a binary image
+format such as PNG or JPEG, an SVG image and a Mermaid diagram are each just
+text, so they can be contained inline in the text of a Markua document. And,
+unlike any other format that can appear after a code fence (such as `ruby` or
+`xml`, which produce a resource of `type` `code`), `svg` and `mermaid` each
+default to a `type` of `image` rather than `code`. In other words, a fenced
+code block of `` ```svg `` or `` ```mermaid `` is rendered as an image by
+default, rather than displayed as source. This is discussed in the Inline SVG
+images and Mermaid diagrams sections below.
+
 Markua uses the image syntax for all resource types. Markua also reinterprets
 images as being a resource. This is important for the following reason:
 
@@ -15932,7 +15952,19 @@ To add an inline SVG image, you create a fenced code block, and then you
 indicate that instead of code, you are inserting a resource of type image
 and of format SVG.
 
-There are two ways to do this.  Here's the verbose way:
+The most natural way is to put `svg` directly after the opening code fence.
+Because the `svg` format defaults to a `type` of `image`, this is rendered as
+an image, not displayed as the XML source of the SVG image:
+
+~~~
+```svg
+<svg width="20" height="20">
+  <circle cx="10" cy="10" r="9" fill="blue"/>
+</svg>
+```
+~~~
+
+You can also be verbose and specify both the `type` and the `format`:
 
 ~~~
 {type: image, format: svg}
@@ -15943,7 +15975,7 @@ There are two ways to do this.  Here's the verbose way:
 ```
 ~~~
 
-Here's the syntactic sugar way:
+There is also a syntactic sugar way, using a `!` after the opening code fence:
 
 ~~~
 ```!
@@ -15961,14 +15993,14 @@ Inline SVG images support all the normal image resource attributes:
 
 ~~~
 {alt: "a blue circle", title: "Earth From Space (Simplified)"}
-```!
+```svg
 <svg width="20" height="20">
   <circle cx="10" cy="10" r="9" fill="blue"/>
 </svg>
 ```
 ~~~
 
-You can use them with the verbose way as well:
+You can use them with any of the ways above:
 
 ~~~
 {type: image, format: svg, alt: "foo", title: "bar"}
@@ -15985,21 +16017,12 @@ you are really doing is creating a code resource. This is discussed below.
 ### Writing about SVG
 
 If you want to write about the SVG format, and show the actual SVG source
-(instead of the image produced), it needs to be of a `format` of `code`, not
-`image`.
+(instead of the image produced), you need a `type` of `code` rather than the
+default `type` of `image`.
 
-Now, you can just be lazy and not provide `format` or `type` attributes at all,
-since guessing when neither is present always produces a type of `code`.
-
-~~~
-```
-<svg width="20" height="20">
-  <circle cx="10" cy="10" r="9" fill="blue"/>
-</svg>
-```
-~~~
-
-However, you can also just specify both, either this way...
+Since the `svg` format defaults to a `type` of `image`, a bare `` ```svg ``
+renders as an image. To show the source instead, override the type with
+`{type: code}`, just as you would for a Mermaid diagram:
 
 ~~~
 {type: code}
@@ -16010,7 +16033,7 @@ However, you can also just specify both, either this way...
 ```
 ~~~
 
-...or this way:
+This is the same as specifying both attributes:
 
 ~~~
 {type: code, format: svg}
@@ -16021,11 +16044,11 @@ However, you can also just specify both, either this way...
 ```
 ~~~
 
-...or this way:
+Alternatively, you can be lazy and not provide `format` or `type` attributes at
+all, since guessing when neither is present always produces a type of `code`:
 
 ~~~
-
-```svg
+```
 <svg width="20" height="20">
   <circle cx="10" cy="10" r="9" fill="blue"/>
 </svg>
@@ -16061,6 +16084,115 @@ Heck, you can even use tildes to do that:
 </svg>
 ~~~
 ```
+
+</div>
+
+
+
+<div class="extension">
+
+## Mermaid diagrams (M)
+
+[Mermaid](https://mermaid.js.org) is a text-based syntax for describing
+diagrams, such as flowcharts, sequence diagrams and Gantt charts. Like an SVG
+image, a Mermaid diagram is just text, so it can be contained inline in the text
+of a Markua document. (This is not true for binary resources like PNG or JPEG
+images, which can only be local or web resources.)
+
+A Mermaid diagram is an image resource whose `format` is `mermaid`. By default,
+a resource with a `format` of `mermaid` has a `type` of `image`: the Markua
+Processor renders the Mermaid source into a diagram, rather than displaying the
+source as code.
+
+In this respect, `mermaid` behaves just like the `svg` format. These are the
+only two formats that, when placed after a code fence, produce a resource of
+`type` `image` by default. For every other format (such as `ruby` or `xml`), a
+bare fenced code block produces a resource of `type` `code`, and the format is
+only used to select syntax highlighting. For `svg` and `mermaid`, the default
+`type` is `image`.
+
+There are several equivalent ways to insert a Mermaid diagram.
+
+Here's the verbose way, specifying both the `type` and the `format`:
+
+~~~
+{type: image, format: mermaid}
+```
+sequenceDiagram
+    Starbuck->>Apollo: You have a go.
+```
+~~~
+
+Since a `format` of `mermaid` implies a `type` of `image`, you can omit the
+`type` and just specify the `format`:
+
+~~~
+{format: mermaid}
+```
+sequenceDiagram
+    Starbuck->>Apollo: You have a go.
+```
+~~~
+
+The most natural way, however, is to put `mermaid` directly after the opening
+code fence, exactly as you would in other Markdown tools. Because the `mermaid`
+format defaults to a `type` of `image`, this renders as a diagram:
+
+~~~
+```mermaid
+sequenceDiagram
+    Starbuck->>Apollo: You have a go.
+```
+~~~
+
+This is equivalent to explicitly specifying the `type`:
+
+~~~
+{type: image}
+```mermaid
+sequenceDiagram
+    Starbuck->>Apollo: You have a go.
+```
+~~~
+
+Mermaid diagrams support all the normal image resource attributes, such as
+`alt`, `title`, `width`, `height`, `align` and `float`:
+
+~~~
+{alt: "a sequence diagram", title: "The Go Order", width: 60%}
+```mermaid
+sequenceDiagram
+    Starbuck->>Apollo: You have a go.
+```
+~~~
+
+### Writing about Mermaid
+
+If you want to write about the Mermaid format, and show the actual Mermaid
+source (instead of the diagram produced), you need a `type` of `code` rather
+than the default `type` of `image`.
+
+You do this by overriding the `type` in an attribute list:
+
+~~~
+{type: code}
+```mermaid
+sequenceDiagram
+    Starbuck->>Apollo: You have a go.
+```
+~~~
+
+This displays the Mermaid source as a code resource (using `mermaid` for syntax
+highlighting), rather than rendering it as a diagram. This is the same as
+specifying both attributes:
+
+~~~
+{type: code, format: mermaid}
+```
+sequenceDiagram
+    Starbuck->>Apollo: You have a go.
+```
+~~~
 
 </div>
 


### PR DESCRIPTION
## Summary

This PR adds first-class support for **Mermaid diagrams** to Markua, and aligns **inline SVG** with the same model. Bumps the spec to **0.31.48** and regenerates `spec.html`.

The unifying idea: a fenced code block whose info string names a *text-based image format* should render as an image by default, rather than be displayed as source. Two formats qualify — `svg` and `mermaid` — because their source is just text and so can live inline in a Markua document (unlike binary formats such as PNG or JPEG, which can only be local or web resources).

## What changed

### New: Mermaid diagrams

- Added `mermaid` to the list of image resource formats (file extensions `.mmd` / `.mermaid`).
- A `format` of `mermaid` defaults to a `type` of `image`: the Markua Processor renders the source into a diagram.
- New **"Mermaid diagrams (M)"** section documenting the equivalent ways to insert one:
  - ` ```mermaid ` (the natural way — renders as a diagram)
  - `{format: mermaid}` + fence (format implies type image)
  - `{type: image, format: mermaid}` + fence (verbose)
  - `{type: image}` + ` ```mermaid ` (explicit)
  - Supports all normal image attributes (`alt`, `title`, `width`, `height`, `align`, `float`).
- **"Writing about Mermaid"** subsection: to show the Mermaid *source* as code, override with `{type: code}` (or `{type: code, format: mermaid}`).

### Changed: SVG now defaults to type image

Previously a bare ` ```svg ` produced a **code** resource, and rendering inline SVG required either the verbose `{type: image, format: svg}` or the `!` shorthand. SVG now behaves exactly like Mermaid:

- A bare ` ```svg ` defaults to `type: image` and renders as an image.
- The verbose `{type: image, format: svg}` form and the ` ```! ` shorthand are **unchanged** and still work.
- **"Writing about SVG"** rewritten: to show SVG *source*, override with `{type: code}` (consistent with Mermaid). The lazy bare ` ``` ` (guess → code), ` ```xml `, and ` ```text ` paths still display source and remain valid.

### Cross-references and bookkeeping

- The image-formats list and the code-resources section now both note that `svg` and `mermaid` are the only two fence formats that default to `type: image`.
- Bumped version to `0.31.48`, date `2026-06-30`.
- Regenerated `spec.html`.

## Compatibility note

The SVG change is a **behavioral change**: documents that wrote ` ```svg ` expecting to display the XML source will now render it as an image. The fix for such cases is to add `{type: code}`. Authors who used the `!` shorthand or attribute lists to render SVG are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
