### PR TITLE
Require footnote and endnote support in headings (0.31.50)

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -20124,31 +20124,31 @@ If you wish to refer to a parenthetical piece of text from multiple places in a
 Markua document, the best approach is to put it in a section (or sub-section,
 sub-sub-section, etc.) or aside and refer to it from multiple places using a
 <a href="#crosslinks">crosslink</a>.</p>
-<h3 id="footnote-and-endnote-support-is-required-for-paragraphs-only" class="definition">
-<span class="number">11.20.4</span>Footnote and endnote support is required for paragraphs only
+<h3 id="footnote-and-endnote-support-is-required-for-paragraphs-and-headings" class="definition">
+<span class="number">11.20.4</span>Footnote and endnote support is required for paragraphs and headings
 </h3>
 <p>A Markua Processor must support footnote and endnote references inserted in
-normal paragraph content. However, that’s it.</p>
-<p>However, sometimes authors want to get creative with their footnotes and
-endnotes. Sometimes they want to add them in headings, or in footnotes or
-endnotes themselves. This latter style has been used on rare occasions, most
-notably by David Foster Wallace.</p>
-<p>However, supporting inserting footnotes and endnotes in places other than normal
-paragraph content puts a hugely increased burden on implementors of Markua
-Processors. As such, there is no requirement for a Markua Processor to support
-inserting a footnote or endnote anywhere other than in normal paragraph content.</p>
-<p>That said, a Markua Processor may support inserting footnote and endnote
-references in headings. A Markua Processor which does so should output the note
-marker on the heading itself, but should omit the note marker and the note
-content anywhere the heading text is reused: in any table of contents, running
-headers, PDF bookmarks, and in any automatically generated heading id. (In other
-words, the automatically generated id of <code>## Great advice[^advice]</code> is
-<code>great-advice</code>, exactly as if the footnote reference was not present.)</p>
+normal paragraph content and in headings. However, that’s it.</p>
+<p>When a footnote or endnote is referenced in a heading, the note marker is
+output on the heading itself. However, the note marker and the note content
+must be omitted anywhere the heading text is reused: in any table of contents,
+running headers, PDF bookmarks, and in any automatically generated heading id.
+(In other words, the automatically generated id of <code>## Great advice[^advice]</code>
+is <code>great-advice</code>, exactly as if the footnote reference was not present.)</p>
+<p>However, sometimes authors want to get even more creative with their footnotes
+and endnotes. Sometimes they want to add them in footnotes or endnotes
+themselves. This style has been used on rare occasions, most notably by David
+Foster Wallace.</p>
+<p>However, supporting inserting footnotes and endnotes in places other than
+normal paragraph content and headings puts a hugely increased burden on
+implementors of Markua Processors. As such, there is no requirement for a
+Markua Processor to support inserting a footnote or endnote anywhere other
+than in normal paragraph content and headings.</p>
 <p>Authors should <strong>not</strong> assume that a particular Markua Processor supports
 inserting a footnote or endnote anywhere other than in normal paragraph content
-unless its documentation specifically states that it does. For example, Leanpub
-supports inserting footnotes and endnotes in headings, as well as in normal
-paragraph content.</p>
+and headings unless its documentation specifically states that it does. For
+example, Leanpub supports inserting footnotes and endnotes in normal paragraph
+content and headings, but not inside footnotes or endnotes themselves.</p>
 </div>
 <div class="extension">
 <h2 id="underline-m-" class="definition">

--- a/spec.html
+++ b/spec.html
@@ -114,7 +114,7 @@ $(document).ready(function() {
 </head>
 <body>
 <h1 class="title">Markua Spec</h1>
-<div class="version">Version 0.31.49 (2026-06-30)</div>
+<div class="version">Version 0.31.50 (2026-08-11)</div>
 <div class="authors">
     <span class="author"><em>This formal specification of Markua was developed at <a href="https://leanpub.com">Leanpub</a>, is written by Peter Armstrong, is based on the CommonMark Spec (version 0.31.2) by John MacFarlane, and is licensed under the Creative Commons license CC-BY-SA 4.0.</em><br/><br/><hr/><br/>NOTE: If you are a Leanpub author, there are two different versions of Markua used on Leanpub. <strong>The default version of Markua for books on Leanpub is Markua 0.30, which is documented in this specification, and which is currently in beta on Leanpub.</strong> The default version of Markua for courses on Leanpub is still Markua 0.10, which is documented in <a href="https://leanpub.com/markua/read">The Markua Manual</a>. (You can still use Markua 0.10 and Leanpub Flavoured Markdown for books on Leanpub, of course.)<br/><br/><hr/><br/></span>
 </div>
@@ -20137,10 +20137,18 @@ notably by David Foster Wallace.</p>
 paragraph content puts a hugely increased burden on implementors of Markua
 Processors. As such, there is no requirement for a Markua Processor to support
 inserting a footnote or endnote anywhere other than in normal paragraph content.</p>
+<p>That said, a Markua Processor may support inserting footnote and endnote
+references in headings. A Markua Processor which does so should output the note
+marker on the heading itself, but should omit the note marker and the note
+content anywhere the heading text is reused: in any table of contents, running
+headers, PDF bookmarks, and in any automatically generated heading id. (In other
+words, the automatically generated id of <code>## Great advice[^advice]</code> is
+<code>great-advice</code>, exactly as if the footnote reference was not present.)</p>
 <p>Authors should <strong>not</strong> assume that a particular Markua Processor supports
 inserting a footnote or endnote anywhere other than in normal paragraph content
 unless its documentation specifically states that it does. For example, Leanpub
-only supports inserting footnotes or endnotes in normal paragraph content.</p>
+supports inserting footnotes and endnotes in headings, as well as in normal
+paragraph content.</p>
 </div>
 <div class="extension">
 <h2 id="underline-m-" class="definition">

--- a/spec.txt
+++ b/spec.txt
@@ -17477,34 +17477,34 @@ Markua document, the best approach is to put it in a section (or sub-section,
 sub-sub-section, etc.) or aside and refer to it from multiple places using a
 [crosslink](#crosslinks).
 
-### Footnote and endnote support is required for paragraphs only
+### Footnote and endnote support is required for paragraphs and headings
 
 A Markua Processor must support footnote and endnote references inserted in
-normal paragraph content. However, that's it.
+normal paragraph content and in headings. However, that's it.
 
-However, sometimes authors want to get creative with their footnotes and
-endnotes. Sometimes they want to add them in headings, or in footnotes or
-endnotes themselves. This latter style has been used on rare occasions, most
-notably by David Foster Wallace.
+When a footnote or endnote is referenced in a heading, the note marker is
+output on the heading itself. However, the note marker and the note content
+must be omitted anywhere the heading text is reused: in any table of contents,
+running headers, PDF bookmarks, and in any automatically generated heading id.
+(In other words, the automatically generated id of `## Great advice[^advice]`
+is `great-advice`, exactly as if the footnote reference was not present.)
 
-However, supporting inserting footnotes and endnotes in places other than normal
-paragraph content puts a hugely increased burden on implementors of Markua
-Processors. As such, there is no requirement for a Markua Processor to support
-inserting a footnote or endnote anywhere other than in normal paragraph content.
+However, sometimes authors want to get even more creative with their footnotes
+and endnotes. Sometimes they want to add them in footnotes or endnotes
+themselves. This style has been used on rare occasions, most notably by David
+Foster Wallace.
 
-That said, a Markua Processor may support inserting footnote and endnote
-references in headings. A Markua Processor which does so should output the note
-marker on the heading itself, but should omit the note marker and the note
-content anywhere the heading text is reused: in any table of contents, running
-headers, PDF bookmarks, and in any automatically generated heading id. (In other
-words, the automatically generated id of `## Great advice[^advice]` is
-`great-advice`, exactly as if the footnote reference was not present.)
+However, supporting inserting footnotes and endnotes in places other than
+normal paragraph content and headings puts a hugely increased burden on
+implementors of Markua Processors. As such, there is no requirement for a
+Markua Processor to support inserting a footnote or endnote anywhere other
+than in normal paragraph content and headings.
 
 Authors should **not** assume that a particular Markua Processor supports
 inserting a footnote or endnote anywhere other than in normal paragraph content
-unless its documentation specifically states that it does. For example, Leanpub
-supports inserting footnotes and endnotes in headings, as well as in normal
-paragraph content.
+and headings unless its documentation specifically states that it does. For
+example, Leanpub supports inserting footnotes and endnotes in normal paragraph
+content and headings, but not inside footnotes or endnotes themselves.
 
 </div>
 

--- a/spec.txt
+++ b/spec.txt
@@ -1,8 +1,8 @@
 ---
 title: Markua Spec
 author: '*This formal specification of Markua was developed at [Leanpub](https://leanpub.com), is written by Peter Armstrong, is based on the CommonMark Spec (version 0.31.2) by John MacFarlane, and is licensed under the Creative Commons license CC-BY-SA 4.0.*<br/><br/><hr/><br/>NOTE: If you are a Leanpub author, there are two different versions of Markua used on Leanpub. <strong>The default version of Markua for books on Leanpub is Markua 0.30, which is documented in this specification, and which is currently in beta on Leanpub.</strong> The default version of Markua for courses on Leanpub is still Markua 0.10, which is documented in [The Markua Manual](https://leanpub.com/markua/read). (You can still use Markua 0.10 and Leanpub Flavoured Markdown for books on Leanpub, of course.)<br/><br/><hr/><br/>'
-version: '0.31.49'
-date: '2026-06-30'
+version: '0.31.50'
+date: '2026-08-11'
 license: '[CC-BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/)'
 ...
 
@@ -17492,10 +17492,19 @@ paragraph content puts a hugely increased burden on implementors of Markua
 Processors. As such, there is no requirement for a Markua Processor to support
 inserting a footnote or endnote anywhere other than in normal paragraph content.
 
+That said, a Markua Processor may support inserting footnote and endnote
+references in headings. A Markua Processor which does so should output the note
+marker on the heading itself, but should omit the note marker and the note
+content anywhere the heading text is reused: in any table of contents, running
+headers, PDF bookmarks, and in any automatically generated heading id. (In other
+words, the automatically generated id of `## Great advice[^advice]` is
+`great-advice`, exactly as if the footnote reference was not present.)
+
 Authors should **not** assume that a particular Markua Processor supports
 inserting a footnote or endnote anywhere other than in normal paragraph content
 unless its documentation specifically states that it does. For example, Leanpub
-only supports inserting footnotes or endnotes in normal paragraph content.
+supports inserting footnotes and endnotes in headings, as well as in normal
+paragraph content.
 
 </div>
 


### PR DESCRIPTION
## What changed

Leanpub now supports footnotes and endnotes in headings (leanpub PR [#7781](https://github.com/rubosstech/leanpub/pull/7781), PROD-12192), and since the only notable real-world Markua implementation is Leanpub, the spec makes this **required** rather than optional — bumping the spec to **0.31.50**.

The "Footnote and endnote support is required for paragraphs only" section becomes "**required for paragraphs and headings**":

- **A Markua Processor must support footnote and endnote references in headings**, exactly as in normal paragraph content.
- The output contract: the note marker renders on the heading itself, while the marker and note content **must be omitted** anywhere the heading text is reused — tables of contents, running headers, PDF bookmarks, and auto-generated heading ids (`## Great advice[^advice]` still gets id `great-advice`).
- Footnotes-in-footnotes (the David Foster Wallace case) remains not required, and Leanpub does not support it; the burden rationale for everything beyond paragraphs + headings stays.
- The Leanpub example sentence now says: Leanpub supports footnotes and endnotes in normal paragraph content and headings, but not inside footnotes or endnotes themselves.

Two commits: the first added heading support as an optional capability; the second strengthens it to required. The section rename changes its generated anchor (`#footnote-and-endnote-support-is-required-for-paragraphs-and-headings`); nothing referenced the old one.

`spec.html` regenerated via the Docker/lua toolchain; the diff contains only the version line and this section. Release-checklist steps (tag, npm publish, site update) are not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DSavBvjt6ybTxF3rkUga4v
