### PR TITLE
Add blanks (fill-in-the-blank) and the thematic-break-style setting (0.31.51)

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -114,7 +114,7 @@ $(document).ready(function() {
 </head>
 <body>
 <h1 class="title">Markua Spec</h1>
-<div class="version">Version 0.31.50 (2026-08-11)</div>
+<div class="version">Version 0.31.51 (2026-08-12)</div>
 <div class="authors">
     <span class="author"><em>This formal specification of Markua was developed at <a href="https://leanpub.com">Leanpub</a>, is written by Peter Armstrong, is based on the CommonMark Spec (version 0.31.2) by John MacFarlane, and is licensed under the Creative Commons license CC-BY-SA 4.0.</em><br/><br/><hr/><br/>NOTE: If you are a Leanpub author, there are two different versions of Markua used on Leanpub. <strong>The default version of Markua for books on Leanpub is Markua 0.30, which is documented in this specification, and which is currently in beta on Leanpub.</strong> The default version of Markua for courses on Leanpub is still Markua 0.10, which is documented in <a href="https://leanpub.com/markua/read">The Markua Manual</a>. (You can still use Markua 0.10 and Leanpub Flavoured Markdown for books on Leanpub, of course.)<br/><br/><hr/><br/></span>
 </div>
@@ -279,11 +279,12 @@ $(document).ready(function() {
 <li><a href="#character-substitutions-m-"><span class="number">11.19</span>Character substitutions (M)</a></li>
 <li><a href="#footnotes-and-endnotes-m-"><span class="number">11.20</span>Footnotes and endnotes (M)</a></li>
 <li><a href="#underline-m-"><span class="number">11.21</span>Underline (M)</a></li>
-<li><a href="#superscript-and-subscript-m-"><span class="number">11.22</span>Superscript and subscript (M)</a></li>
-<li><a href="#strikethrough-gfm-"><span class="number">11.23</span>Strikethrough (GFM)</a></li>
-<li><a href="#index-entries-m-"><span class="number">11.24</span>Index entries (M)</a></li>
-<li><a href="#syntactic-sugar-list-m-"><span class="number">11.25</span>Syntactic sugar list (M)</a></li>
-<li><a href="#textual-content"><span class="number">11.26</span>Textual content</a></li>
+<li><a href="#blanks-m-"><span class="number">11.22</span>Blanks (M)</a></li>
+<li><a href="#superscript-and-subscript-m-"><span class="number">11.23</span>Superscript and subscript (M)</a></li>
+<li><a href="#strikethrough-gfm-"><span class="number">11.24</span>Strikethrough (GFM)</a></li>
+<li><a href="#index-entries-m-"><span class="number">11.25</span>Index entries (M)</a></li>
+<li><a href="#syntactic-sugar-list-m-"><span class="number">11.26</span>Syntactic sugar list (M)</a></li>
+<li><a href="#textual-content"><span class="number">11.27</span>Textual content</a></li>
 </ul>
 </li>
 <li><a href="#appendix-a-parsing-strategy">Appendix: A parsing strategy</a>
@@ -3528,8 +3529,10 @@ the defaults are in one list. These defaults are listed below.</p>
   restart-endnote-numbering: true
   restart-footnote-numbering: true
   section-number-format: name
+  show-blank-answers: false
   soft-breaks: space
   table-name: figure
+  thematic-break-style: rule
   toc-chapter-number-format: name
   toc-part-number-format: name
   toc-section-number-format: name
@@ -3687,6 +3690,12 @@ at the end of a chapter.</p>
 the section heading in the body of the book. The format of the section heading
 in the table of contents is set by the related <code>toc-section-number-format</code>
 setting.</p>
+<p><code>show-blank-answers</code>
+: <code>true</code> or <code>false</code>. The default value is <code>false</code>. If <code>false</code>, the <code>answer</code>
+attribute of a <a href="#blanks-m-">blank</a> is consumed and does not appear in the
+output. If <code>true</code>, every answer is rendered inside its blank, so that one
+manuscript can produce both the student edition and the answer key or
+teacher’s edition of a workbook. This is discussed <a href="#blanks-m-">here</a>.</p>
 <p><code>soft-breaks</code>
 : <code>break</code> or <code>space</code>. The default is <code>space</code>, for compatibility with
 Markdown. This setting determines the behavior of single newlines (i.e. a
@@ -3702,6 +3711,15 @@ This is what tables get referred to as in crosslinks and lists of figures.
 The reason that this is standardized on two choices, instead of just an
 arbitrary string, is to make things more consistent for readers, and easier to
 implement for builders of Markua Processors.</p>
+<p><code>thematic-break-style</code>
+: <code>rule</code>, <code>asterism</code>, <code>space</code> or <code>full-width-line</code>. The default is <code>rule</code>.
+This setting controls how thematic breaks are rendered: as a conventional
+horizontal rule (<code>rule</code>), as a centered scene break ornament (<code>asterism</code>),
+as blank vertical space (<code>space</code>), or as a full-width ruled line for the
+reader to write an answer on (<code>full-width-line</code>), which is the writing line
+found in workbooks and study guides. Parsing is unaffected: this is purely
+a rendering choice. This is discussed in the
+<a href="#thematic-breaks">section on thematic breaks</a>.</p>
 <p><code>toc-chapter-number-format</code>
 : <code>category_number_name</code> (e.g. Chapter 1: The Chapter Name), <code>category_number</code>
 (e.g. Chapter 1), <code>number_name</code> (e.g. 1. The Chapter Name), <code>number</code> (e.g. 1)
@@ -4864,6 +4882,62 @@ interpretations of a line, the thematic break takes precedence:</p>
 </code></pre>
 </div>
 </div>
+<p>How a thematic break is rendered is a different question from how it is
+parsed, and it is a question authors genuinely care about: a novelist may
+want a scene break rendered as blank vertical space or as a centered
+asterism, while a workbook author may want a full-width ruled line for the
+reader to write an answer on. In Markua, this choice is the
+<code>thematic-break-style</code> document setting. Its value is one of the following:</p>
+<p><code>rule</code>
+: The default: a conventional horizontal rule, used as a separator.</p>
+<p><code>asterism</code>
+: A centered scene break ornament: traditionally three stars (⁂), often
+rendered as three spaced asterisks.</p>
+<p><code>space</code>
+: Blank vertical space, the way scene breaks are most commonly typeset in
+novels.</p>
+<p><code>full-width-line</code>
+: A rule from margin to margin, with generous vertical space around it, for
+the reader to write on. This is the writing line found in workbooks and
+study guides–these lines exist for pens, not cursors. (For a short blank
+inside a sentence, see <a href="#blanks-m-">blanks</a>.)</p>
+<p>With the default <code>rule</code>, the HTML output is a plain <code>&lt;hr /&gt;</code>, as in all of
+the examples above. With any other value, the value is emitted as the class
+of the <code>hr</code> element, and the actual appearance is up to the stylesheet or
+Markua Processor:</p>
+<div class="example" id="example-83">
+<div class="examplenum">
+<a href="#example-83">Example 83</a>
+</div>
+<div class="column">
+<pre><code class="language-markdown">{
+thematic-break-style:<span class="space"> </span>full-width-line
+}
+
+#<span class="space"> </span>Chapter<span class="space"> </span>One
+
+List<span class="space"> </span>three<span class="space"> </span>examples<span class="space"> </span>of<span class="space"> </span>irony:
+
+---
+---
+---
+</code></pre>
+</div>
+<div class="column">
+<pre><code class="language-html">&lt;h1&gt;Chapter<span class="space"> </span>One&lt;/h1&gt;
+&lt;p&gt;List<span class="space"> </span>three<span class="space"> </span>examples<span class="space"> </span>of<span class="space"> </span>irony:&lt;/p&gt;
+&lt;hr<span class="space"> </span>class=&quot;full-width-line&quot;<span class="space"> </span>/&gt;
+&lt;hr<span class="space"> </span>class=&quot;full-width-line&quot;<span class="space"> </span>/&gt;
+&lt;hr<span class="space"> </span>class=&quot;full-width-line&quot;<span class="space"> </span>/&gt;
+</code></pre>
+</div>
+</div>
+<p>Note that since a thematic break is parsed exactly as it is in CommonMark,
+this feature involves no divergence from CommonMark at all: it is purely a
+rendering choice, made the same way Markua makes other rendering choices,
+with a document setting. Like any document setting, <code>thematic-break-style</code>
+applies to the whole document. This setting is also listed in the
+<a href="#the-standard-document-settings-m-">section on standard document settings</a>.</p>
 <h2 id="atx-headings" class="definition">
 <span class="number">7.2</span>ATX headings
 </h2>
@@ -4879,9 +4953,9 @@ contents of the heading are stripped of leading and trailing space or tabs
 before being parsed as inline content.  The heading level is equal to the number
 of <code>#</code> characters in the opening sequence.</p>
 <p>Simple headings:</p>
-<div class="example" id="example-83">
+<div class="example" id="example-84">
 <div class="examplenum">
-<a href="#example-83">Example 83</a>
+<a href="#example-84">Example 84</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">#<span class="space"> </span>foo
@@ -4903,9 +4977,9 @@ of <code>#</code> characters in the opening sequence.</p>
 </div>
 </div>
 <p>More than six <code>#</code> characters is not a heading:</p>
-<div class="example" id="example-84">
+<div class="example" id="example-85">
 <div class="examplenum">
-<a href="#example-84">Example 84</a>
+<a href="#example-85">Example 85</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">#######<span class="space"> </span>foo
@@ -4923,9 +4997,9 @@ space was required by the
 <a href="http://www.aaronsw.com/2002/atx/atx.py">original ATX implementation</a>,
 and it helps prevent things like the following from being parsed as
 headings:</p>
-<div class="example" id="example-85">
+<div class="example" id="example-86">
 <div class="examplenum">
-<a href="#example-85">Example 85</a>
+<a href="#example-86">Example 86</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">#5<span class="space"> </span>bolt
@@ -4940,9 +5014,9 @@ headings:</p>
 </div>
 </div>
 <p>This is not a heading, because the first <code>#</code> is escaped:</p>
-<div class="example" id="example-86">
+<div class="example" id="example-87">
 <div class="examplenum">
-<a href="#example-86">Example 86</a>
+<a href="#example-87">Example 87</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">\##<span class="space"> </span>foo
@@ -4954,9 +5028,9 @@ headings:</p>
 </div>
 </div>
 <p>Contents are parsed as inlines:</p>
-<div class="example" id="example-87">
+<div class="example" id="example-88">
 <div class="examplenum">
-<a href="#example-87">Example 87</a>
+<a href="#example-88">Example 88</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">#<span class="space"> </span>foo<span class="space"> </span>*bar*<span class="space"> </span>\*baz\*
@@ -4968,9 +5042,9 @@ headings:</p>
 </div>
 </div>
 <p>Leading and trailing spaces or tabs are ignored in parsing inline content:</p>
-<div class="example" id="example-88">
+<div class="example" id="example-89">
 <div class="examplenum">
-<a href="#example-88">Example 88</a>
+<a href="#example-89">Example 89</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">#<span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="space"> </span>foo<span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="space"> </span>
@@ -4982,9 +5056,9 @@ headings:</p>
 </div>
 </div>
 <p>Up to three spaces of indentation are allowed:</p>
-<div class="example" id="example-89">
+<div class="example" id="example-90">
 <div class="examplenum">
-<a href="#example-89">Example 89</a>
+<a href="#example-90">Example 90</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown"><span class="space"> </span>###<span class="space"> </span>foo
@@ -5000,9 +5074,9 @@ headings:</p>
 </div>
 </div>
 <p>Four spaces of indentation is too many:</p>
-<div class="example" id="example-90">
+<div class="example" id="example-91">
 <div class="examplenum">
-<a href="#example-90">Example 90</a>
+<a href="#example-91">Example 91</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown"><span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="space"> </span>#<span class="space"> </span>foo
@@ -5014,9 +5088,9 @@ headings:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-91">
+<div class="example" id="example-92">
 <div class="examplenum">
-<a href="#example-91">Example 91</a>
+<a href="#example-92">Example 92</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">foo
@@ -5030,9 +5104,9 @@ headings:</p>
 </div>
 </div>
 <p>A closing sequence of <code>#</code> characters is optional:</p>
-<div class="example" id="example-92">
+<div class="example" id="example-93">
 <div class="examplenum">
-<a href="#example-92">Example 92</a>
+<a href="#example-93">Example 93</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">##<span class="space"> </span>foo<span class="space"> </span>##
@@ -5046,9 +5120,9 @@ headings:</p>
 </div>
 </div>
 <p>It need not be the same length as the opening sequence:</p>
-<div class="example" id="example-93">
+<div class="example" id="example-94">
 <div class="examplenum">
-<a href="#example-93">Example 93</a>
+<a href="#example-94">Example 94</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">#<span class="space"> </span>foo<span class="space"> </span>##################################
@@ -5062,9 +5136,9 @@ headings:</p>
 </div>
 </div>
 <p>Spaces or tabs are allowed after the closing sequence:</p>
-<div class="example" id="example-94">
+<div class="example" id="example-95">
 <div class="examplenum">
-<a href="#example-94">Example 94</a>
+<a href="#example-95">Example 95</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">###<span class="space"> </span>foo<span class="space"> </span>###<span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="space"> </span>
@@ -5078,9 +5152,9 @@ headings:</p>
 <p>A sequence of <code>#</code> characters with anything but spaces or tabs following it
 is not a closing sequence, but counts as part of the contents of the
 heading:</p>
-<div class="example" id="example-95">
+<div class="example" id="example-96">
 <div class="examplenum">
-<a href="#example-95">Example 95</a>
+<a href="#example-96">Example 96</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">###<span class="space"> </span>foo<span class="space"> </span>###<span class="space"> </span>b
@@ -5092,9 +5166,9 @@ heading:</p>
 </div>
 </div>
 <p>The closing sequence must be preceded by a space or tab:</p>
-<div class="example" id="example-96">
+<div class="example" id="example-97">
 <div class="examplenum">
-<a href="#example-96">Example 96</a>
+<a href="#example-97">Example 97</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">#<span class="space"> </span>foo#
@@ -5107,9 +5181,9 @@ heading:</p>
 </div>
 <p>Backslash-escaped <code>#</code> characters do not count as part
 of the closing sequence:</p>
-<div class="example" id="example-97">
+<div class="example" id="example-98">
 <div class="examplenum">
-<a href="#example-97">Example 97</a>
+<a href="#example-98">Example 98</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">###<span class="space"> </span>foo<span class="space"> </span>\###
@@ -5126,9 +5200,9 @@ of the closing sequence:</p>
 </div>
 <p>ATX headings need not be separated from surrounding content by blank
 lines, and they can interrupt paragraphs:</p>
-<div class="example" id="example-98">
+<div class="example" id="example-99">
 <div class="examplenum">
-<a href="#example-98">Example 98</a>
+<a href="#example-99">Example 99</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">****
@@ -5143,9 +5217,9 @@ lines, and they can interrupt paragraphs:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-99">
+<div class="example" id="example-100">
 <div class="examplenum">
-<a href="#example-99">Example 99</a>
+<a href="#example-100">Example 100</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">Foo<span class="space"> </span>bar
@@ -5161,9 +5235,9 @@ Bar<span class="space"> </span>foo
 </div>
 </div>
 <p>ATX headings can be empty:</p>
-<div class="example" id="example-100">
+<div class="example" id="example-101">
 <div class="examplenum">
-<a href="#example-100">Example 100</a>
+<a href="#example-101">Example 101</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">##<span class="space"> </span>
@@ -5203,9 +5277,9 @@ blank line.  However, it cannot interrupt a paragraph, so when a
 setext heading comes after a paragraph, a blank line is needed between
 them.</p>
 <p>Simple examples:</p>
-<div class="example" id="example-101">
+<div class="example" id="example-102">
 <div class="examplenum">
-<a href="#example-101">Example 101</a>
+<a href="#example-102">Example 102</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">Foo<span class="space"> </span>*bar*
@@ -5222,9 +5296,9 @@ Foo<span class="space"> </span>*bar*
 </div>
 </div>
 <p>The content of the header may span more than one line:</p>
-<div class="example" id="example-102">
+<div class="example" id="example-103">
 <div class="examplenum">
-<a href="#example-102">Example 102</a>
+<a href="#example-103">Example 103</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">Foo<span class="space"> </span>*bar
@@ -5242,9 +5316,9 @@ baz&lt;/em&gt;&lt;/h1&gt;
 content as inlines.  The heading’s raw content is formed by
 concatenating the lines and removing initial and final
 spaces or tabs.</p>
-<div class="example" id="example-103">
+<div class="example" id="example-104">
 <div class="examplenum">
-<a href="#example-103">Example 103</a>
+<a href="#example-104">Example 104</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown"><span class="space"> </span><span class="space"> </span>Foo<span class="space"> </span>*bar
@@ -5259,9 +5333,9 @@ baz&lt;/em&gt;&lt;/h1&gt;
 </div>
 </div>
 <p>The underlining can be any length:</p>
-<div class="example" id="example-104">
+<div class="example" id="example-105">
 <div class="examplenum">
-<a href="#example-104">Example 104</a>
+<a href="#example-105">Example 105</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">Foo
@@ -5279,9 +5353,9 @@ Foo
 </div>
 <p>The heading content can be preceded by up to three spaces of indentation, and
 need not line up with the underlining:</p>
-<div class="example" id="example-105">
+<div class="example" id="example-106">
 <div class="examplenum">
-<a href="#example-105">Example 105</a>
+<a href="#example-106">Example 106</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown"><span class="space"> </span><span class="space"> </span><span class="space"> </span>Foo
@@ -5302,9 +5376,9 @@ need not line up with the underlining:</p>
 </div>
 </div>
 <p>Four spaces of indentation is too many:</p>
-<div class="example" id="example-106">
+<div class="example" id="example-107">
 <div class="examplenum">
-<a href="#example-106">Example 106</a>
+<a href="#example-107">Example 107</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown"><span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="space"> </span>Foo
@@ -5326,9 +5400,9 @@ Foo
 </div>
 <p>The setext heading underline can be preceded by up to three spaces of
 indentation, and may have trailing spaces or tabs:</p>
-<div class="example" id="example-107">
+<div class="example" id="example-108">
 <div class="examplenum">
-<a href="#example-107">Example 107</a>
+<a href="#example-108">Example 108</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">Foo
@@ -5341,9 +5415,9 @@ indentation, and may have trailing spaces or tabs:</p>
 </div>
 </div>
 <p>Four spaces of indentation is too many:</p>
-<div class="example" id="example-108">
+<div class="example" id="example-109">
 <div class="examplenum">
-<a href="#example-108">Example 108</a>
+<a href="#example-109">Example 109</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">Foo
@@ -5357,9 +5431,9 @@ indentation, and may have trailing spaces or tabs:</p>
 </div>
 </div>
 <p>The setext heading underline cannot contain internal spaces or tabs:</p>
-<div class="example" id="example-109">
+<div class="example" id="example-110">
 <div class="examplenum">
-<a href="#example-109">Example 109</a>
+<a href="#example-110">Example 110</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">Foo
@@ -5378,9 +5452,9 @@ Foo
 </div>
 </div>
 <p>Trailing spaces or tabs in the content line do not cause a hard line break:</p>
-<div class="example" id="example-110">
+<div class="example" id="example-111">
 <div class="examplenum">
-<a href="#example-110">Example 110</a>
+<a href="#example-111">Example 111</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">Foo<span class="space"> </span><span class="space"> </span>
@@ -5393,9 +5467,9 @@ Foo
 </div>
 </div>
 <p>Nor does a backslash at the end:</p>
-<div class="example" id="example-111">
+<div class="example" id="example-112">
 <div class="examplenum">
-<a href="#example-111">Example 111</a>
+<a href="#example-112">Example 112</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">Foo\
@@ -5409,9 +5483,9 @@ Foo
 </div>
 <p>Since indicators of block structure take precedence over
 indicators of inline structure, the following are setext headings:</p>
-<div class="example" id="example-112">
+<div class="example" id="example-113">
 <div class="examplenum">
-<a href="#example-112">Example 112</a>
+<a href="#example-113">Example 113</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">`Foo
@@ -5433,9 +5507,9 @@ of<span class="space"> </span>dashes&quot;/&gt;
 </div>
 <p>The setext heading underline cannot be a <a href="#lazy-continuation-line">lazy continuation
 line</a> in a list item or block quote:</p>
-<div class="example" id="example-113">
+<div class="example" id="example-114">
 <div class="examplenum">
-<a href="#example-113">Example 113</a>
+<a href="#example-114">Example 114</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">&gt;<span class="space"> </span>Foo
@@ -5450,9 +5524,9 @@ line</a> in a list item or block quote:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-114">
+<div class="example" id="example-115">
 <div class="examplenum">
-<a href="#example-114">Example 114</a>
+<a href="#example-115">Example 115</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">&gt;<span class="space"> </span>foo
@@ -5469,9 +5543,9 @@ bar
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-115">
+<div class="example" id="example-116">
 <div class="examplenum">
-<a href="#example-115">Example 115</a>
+<a href="#example-116">Example 116</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">-<span class="space"> </span>Foo
@@ -5489,9 +5563,9 @@ bar
 <p>A blank line is needed between a paragraph and a following
 setext heading, since otherwise the paragraph becomes part
 of the heading’s content:</p>
-<div class="example" id="example-116">
+<div class="example" id="example-117">
 <div class="examplenum">
-<a href="#example-116">Example 116</a>
+<a href="#example-117">Example 117</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">Foo
@@ -5507,9 +5581,9 @@ Bar&lt;/h2&gt;
 </div>
 <p>But in general a blank line is not required before or after
 setext headings:</p>
-<div class="example" id="example-117">
+<div class="example" id="example-118">
 <div class="examplenum">
-<a href="#example-117">Example 117</a>
+<a href="#example-118">Example 118</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">---
@@ -5529,9 +5603,9 @@ Baz
 </div>
 </div>
 <p>Setext headings cannot be empty:</p>
-<div class="example" id="example-118">
+<div class="example" id="example-119">
 <div class="examplenum">
-<a href="#example-118">Example 118</a>
+<a href="#example-119">Example 119</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">
@@ -5546,9 +5620,9 @@ Baz
 <p>Setext heading text lines must not be interpretable as block
 constructs other than paragraphs.  So, the line of dashes
 in these examples gets interpreted as a thematic break:</p>
-<div class="example" id="example-119">
+<div class="example" id="example-120">
 <div class="examplenum">
-<a href="#example-119">Example 119</a>
+<a href="#example-120">Example 120</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">---
@@ -5561,9 +5635,9 @@ in these examples gets interpreted as a thematic break:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-120">
+<div class="example" id="example-121">
 <div class="examplenum">
-<a href="#example-120">Example 120</a>
+<a href="#example-121">Example 121</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">-<span class="space"> </span>foo
@@ -5578,9 +5652,9 @@ in these examples gets interpreted as a thematic break:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-121">
+<div class="example" id="example-122">
 <div class="examplenum">
-<a href="#example-121">Example 121</a>
+<a href="#example-122">Example 122</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown"><span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="space"> </span>foo
@@ -5594,9 +5668,9 @@ in these examples gets interpreted as a thematic break:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-122">
+<div class="example" id="example-123">
 <div class="examplenum">
-<a href="#example-122">Example 122</a>
+<a href="#example-123">Example 123</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">&gt;<span class="space"> </span>foo
@@ -5613,9 +5687,9 @@ in these examples gets interpreted as a thematic break:</p>
 </div>
 <p>If you want a heading with <code>&gt; foo</code> as its literal text, you can
 use backslash escapes:</p>
-<div class="example" id="example-123">
+<div class="example" id="example-124">
 <div class="examplenum">
-<a href="#example-123">Example 123</a>
+<a href="#example-124">Example 124</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">\&gt;<span class="space"> </span>foo
@@ -5646,9 +5720,9 @@ baz
 increases the expressive power of CommonMark, by allowing
 multiline headings.  Authors who want interpretation 1 can
 put a blank line after the first paragraph:</p>
-<div class="example" id="example-124">
+<div class="example" id="example-125">
 <div class="examplenum">
-<a href="#example-124">Example 124</a>
+<a href="#example-125">Example 125</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">Foo
@@ -5667,9 +5741,9 @@ baz
 </div>
 <p>Authors who want interpretation 2 can put blank lines around
 the thematic break,</p>
-<div class="example" id="example-125">
+<div class="example" id="example-126">
 <div class="examplenum">
-<a href="#example-125">Example 125</a>
+<a href="#example-126">Example 126</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">Foo
@@ -5690,9 +5764,9 @@ bar&lt;/p&gt;
 </div>
 <p>or use a thematic break that cannot count as a <a href="#setext-heading-underline">setext heading
 underline</a>, such as</p>
-<div class="example" id="example-126">
+<div class="example" id="example-127">
 <div class="examplenum">
-<a href="#example-126">Example 126</a>
+<a href="#example-127">Example 127</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">Foo
@@ -5710,9 +5784,9 @@ bar&lt;/p&gt;
 </div>
 </div>
 <p>Authors who want interpretation 3 can use backslash escapes:</p>
-<div class="example" id="example-127">
+<div class="example" id="example-128">
 <div class="examplenum">
-<a href="#example-127">Example 127</a>
+<a href="#example-128">Example 128</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">Foo
@@ -5743,9 +5817,9 @@ An indented code block has no <a href="#info-string">info string</a>.</p>
 a blank line between a paragraph and a following indented code block.
 (A blank line is not needed, however, between a code block and a following
 paragraph.)</p>
-<div class="example" id="example-128">
+<div class="example" id="example-129">
 <div class="examplenum">
-<a href="#example-128">Example 128</a>
+<a href="#example-129">Example 129</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown"><span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="space"> </span>a<span class="space"> </span>simple
@@ -5762,9 +5836,9 @@ paragraph.)</p>
 <p>If there is any ambiguity between an interpretation of indentation
 as a code block and as indicating that material belongs to a <a href="#list-items">list
 item</a>, the list item interpretation takes precedence:</p>
-<div class="example" id="example-129">
+<div class="example" id="example-130">
 <div class="examplenum">
-<a href="#example-129">Example 129</a>
+<a href="#example-130">Example 130</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown"><span class="space"> </span><span class="space"> </span>-<span class="space"> </span>foo
@@ -5782,9 +5856,9 @@ item</a>, the list item interpretation takes precedence:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-130">
+<div class="example" id="example-131">
 <div class="examplenum">
-<a href="#example-130">Example 130</a>
+<a href="#example-131">Example 131</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">1.<span class="space"> </span><span class="space"> </span>foo
@@ -5806,9 +5880,9 @@ item</a>, the list item interpretation takes precedence:</p>
 </div>
 <p>The contents of a code block are literal text, and do not get parsed
 as Markdown:</p>
-<div class="example" id="example-131">
+<div class="example" id="example-132">
 <div class="examplenum">
-<a href="#example-131">Example 131</a>
+<a href="#example-132">Example 132</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown"><span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="space"> </span>&lt;a/&gt;
@@ -5827,9 +5901,9 @@ as Markdown:</p>
 </div>
 </div>
 <p>Here we have three chunks separated by blank lines:</p>
-<div class="example" id="example-132">
+<div class="example" id="example-133">
 <div class="examplenum">
-<a href="#example-132">Example 132</a>
+<a href="#example-133">Example 133</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown"><span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="space"> </span>chunk1
@@ -5855,9 +5929,9 @@ chunk3
 </div>
 <p>Any initial spaces or tabs beyond four spaces of indentation will be included in
 the content, even in interior blank lines:</p>
-<div class="example" id="example-133">
+<div class="example" id="example-134">
 <div class="examplenum">
-<a href="#example-133">Example 133</a>
+<a href="#example-134">Example 134</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown"><span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="space"> </span>chunk1
@@ -5875,9 +5949,9 @@ the content, even in interior blank lines:</p>
 </div>
 <p>An indented code block cannot interrupt a paragraph.  (This
 allows hanging indents and the like.)</p>
-<div class="example" id="example-134">
+<div class="example" id="example-135">
 <div class="examplenum">
-<a href="#example-134">Example 134</a>
+<a href="#example-135">Example 135</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">Foo
@@ -5893,9 +5967,9 @@ bar&lt;/p&gt;
 <p>However, any non-blank line with fewer than four spaces of indentation ends
 the code block immediately.  So a paragraph may occur immediately
 after indented code:</p>
-<div class="example" id="example-135">
+<div class="example" id="example-136">
 <div class="examplenum">
-<a href="#example-135">Example 135</a>
+<a href="#example-136">Example 136</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown"><span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="space"> </span>foo
@@ -5911,9 +5985,9 @@ bar
 </div>
 <p>And indented code can occur immediately before and after other kinds of
 blocks:</p>
-<div class="example" id="example-136">
+<div class="example" id="example-137">
 <div class="examplenum">
-<a href="#example-136">Example 136</a>
+<a href="#example-137">Example 137</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">#<span class="space"> </span>Heading
@@ -5936,9 +6010,9 @@ Heading
 </div>
 </div>
 <p>The first line can be preceded by more than four spaces of indentation:</p>
-<div class="example" id="example-137">
+<div class="example" id="example-138">
 <div class="examplenum">
-<a href="#example-137">Example 137</a>
+<a href="#example-138">Example 138</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown"><span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="space"> </span>foo
@@ -5954,9 +6028,9 @@ bar
 </div>
 <p>Blank lines preceding or following an indented code block
 are not included in it:</p>
-<div class="example" id="example-138">
+<div class="example" id="example-139">
 <div class="examplenum">
-<a href="#example-138">Example 138</a>
+<a href="#example-139">Example 139</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">
@@ -5972,9 +6046,9 @@ are not included in it:</p>
 </div>
 </div>
 <p>Trailing spaces or tabs are included in the code block’s content:</p>
-<div class="example" id="example-139">
+<div class="example" id="example-140">
 <div class="examplenum">
-<a href="#example-139">Example 139</a>
+<a href="#example-140">Example 140</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown"><span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="space"> </span>foo<span class="space"> </span><span class="space"> </span>
@@ -6026,9 +6100,9 @@ specify the language of the code sample, and rendered in the <code>class</code>
 attribute of the <code>code</code> tag.  However, this spec does not mandate any
 particular treatment of the <a href="#info-string">info string</a>.</p>
 <p>Here is a simple example with backticks:</p>
-<div class="example" id="example-140">
+<div class="example" id="example-141">
 <div class="examplenum">
-<a href="#example-140">Example 140</a>
+<a href="#example-141">Example 141</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">```
@@ -6045,9 +6119,9 @@ particular treatment of the <a href="#info-string">info string</a>.</p>
 </div>
 </div>
 <p>With tildes:</p>
-<div class="example" id="example-141">
+<div class="example" id="example-142">
 <div class="examplenum">
-<a href="#example-141">Example 141</a>
+<a href="#example-142">Example 142</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">~~~
@@ -6064,9 +6138,9 @@ particular treatment of the <a href="#info-string">info string</a>.</p>
 </div>
 </div>
 <p>Fewer than three backticks is not enough:</p>
-<div class="example" id="example-142">
+<div class="example" id="example-143">
 <div class="examplenum">
-<a href="#example-142">Example 142</a>
+<a href="#example-143">Example 143</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">``
@@ -6081,9 +6155,9 @@ foo
 </div>
 <p>The closing code fence must use the same character as the opening
 fence:</p>
-<div class="example" id="example-143">
+<div class="example" id="example-144">
 <div class="examplenum">
-<a href="#example-143">Example 143</a>
+<a href="#example-144">Example 144</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">```
@@ -6099,9 +6173,9 @@ aaa
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-144">
+<div class="example" id="example-145">
 <div class="examplenum">
-<a href="#example-144">Example 144</a>
+<a href="#example-145">Example 145</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">~~~
@@ -6118,9 +6192,9 @@ aaa
 </div>
 </div>
 <p>The closing code fence must be at least as long as the opening fence:</p>
-<div class="example" id="example-145">
+<div class="example" id="example-146">
 <div class="examplenum">
-<a href="#example-145">Example 145</a>
+<a href="#example-146">Example 146</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">````
@@ -6136,9 +6210,9 @@ aaa
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-146">
+<div class="example" id="example-147">
 <div class="examplenum">
-<a href="#example-146">Example 146</a>
+<a href="#example-147">Example 147</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">~~~~
@@ -6156,9 +6230,9 @@ aaa
 </div>
 <p>Unclosed code blocks are closed by the end of the document
 (or the enclosing <a href="#block-quotes">block quote</a> or <a href="#list-items">list item</a>):</p>
-<div class="example" id="example-147">
+<div class="example" id="example-148">
 <div class="examplenum">
-<a href="#example-147">Example 147</a>
+<a href="#example-148">Example 148</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">```
@@ -6169,9 +6243,9 @@ aaa
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-148">
+<div class="example" id="example-149">
 <div class="examplenum">
-<a href="#example-148">Example 148</a>
+<a href="#example-149">Example 149</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">`````
@@ -6188,9 +6262,9 @@ aaa
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-149">
+<div class="example" id="example-150">
 <div class="examplenum">
-<a href="#example-149">Example 149</a>
+<a href="#example-150">Example 150</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">&gt;<span class="space"> </span>```
@@ -6209,9 +6283,9 @@ bbb
 </div>
 </div>
 <p>A code block can have all empty lines as its content:</p>
-<div class="example" id="example-150">
+<div class="example" id="example-151">
 <div class="examplenum">
-<a href="#example-150">Example 150</a>
+<a href="#example-151">Example 151</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">```
@@ -6228,9 +6302,9 @@ bbb
 </div>
 </div>
 <p>A code block can be empty:</p>
-<div class="example" id="example-151">
+<div class="example" id="example-152">
 <div class="examplenum">
-<a href="#example-151">Example 151</a>
+<a href="#example-152">Example 152</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">```
@@ -6245,9 +6319,9 @@ bbb
 <p>Fences can be indented.  If the opening fence is indented,
 content lines will have equivalent opening indentation removed,
 if present:</p>
-<div class="example" id="example-152">
+<div class="example" id="example-153">
 <div class="examplenum">
-<a href="#example-152">Example 152</a>
+<a href="#example-153">Example 153</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown"><span class="space"> </span>```
@@ -6263,9 +6337,9 @@ aaa
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-153">
+<div class="example" id="example-154">
 <div class="examplenum">
-<a href="#example-153">Example 153</a>
+<a href="#example-154">Example 154</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown"><span class="space"> </span><span class="space"> </span>```
@@ -6283,9 +6357,9 @@ aaa
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-154">
+<div class="example" id="example-155">
 <div class="examplenum">
-<a href="#example-154">Example 154</a>
+<a href="#example-155">Example 155</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown"><span class="space"> </span><span class="space"> </span><span class="space"> </span>```
@@ -6304,9 +6378,9 @@ aaa
 </div>
 </div>
 <p>Four spaces of indentation is too many:</p>
-<div class="example" id="example-155">
+<div class="example" id="example-156">
 <div class="examplenum">
-<a href="#example-155">Example 155</a>
+<a href="#example-156">Example 156</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown"><span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="space"> </span>```
@@ -6324,9 +6398,9 @@ aaa
 </div>
 <p>Closing fences may be preceded by up to three spaces of indentation, and their
 indentation need not match that of the opening fence:</p>
-<div class="example" id="example-156">
+<div class="example" id="example-157">
 <div class="examplenum">
-<a href="#example-156">Example 156</a>
+<a href="#example-157">Example 157</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">```
@@ -6340,9 +6414,9 @@ aaa
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-157">
+<div class="example" id="example-158">
 <div class="examplenum">
-<a href="#example-157">Example 157</a>
+<a href="#example-158">Example 158</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown"><span class="space"> </span><span class="space"> </span><span class="space"> </span>```
@@ -6357,9 +6431,9 @@ aaa
 </div>
 </div>
 <p>This is not a closing fence, because it is indented 4 spaces:</p>
-<div class="example" id="example-158">
+<div class="example" id="example-159">
 <div class="examplenum">
-<a href="#example-158">Example 158</a>
+<a href="#example-159">Example 159</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">```
@@ -6375,9 +6449,9 @@ aaa
 </div>
 </div>
 <p>Code fences (opening and closing) cannot contain internal spaces or tabs:</p>
-<div class="example" id="example-159">
+<div class="example" id="example-160">
 <div class="examplenum">
-<a href="#example-159">Example 159</a>
+<a href="#example-160">Example 160</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">```<span class="space"> </span>```
@@ -6390,9 +6464,9 @@ aaa&lt;/p&gt;
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-160">
+<div class="example" id="example-161">
 <div class="examplenum">
-<a href="#example-160">Example 160</a>
+<a href="#example-161">Example 161</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">~~~~~~
@@ -6409,9 +6483,9 @@ aaa
 </div>
 <p>Fenced code blocks can interrupt paragraphs, and can be followed
 directly by paragraphs, without a blank line between:</p>
-<div class="example" id="example-161">
+<div class="example" id="example-162">
 <div class="examplenum">
-<a href="#example-161">Example 161</a>
+<a href="#example-162">Example 162</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">foo
@@ -6431,9 +6505,9 @@ baz
 </div>
 <p>Other blocks can also occur before and after fenced code blocks
 without an intervening blank line:</p>
-<div class="example" id="example-162">
+<div class="example" id="example-163">
 <div class="examplenum">
-<a href="#example-162">Example 162</a>
+<a href="#example-163">Example 163</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">foo
@@ -6458,9 +6532,9 @@ the info string, the first word is typically used to specify
 the language of the code block. In HTML output, the language is
 normally indicated by adding a class to the <code>code</code> element consisting
 of <code>language-</code> followed by the language name.</p>
-<div class="example" id="example-163">
+<div class="example" id="example-164">
 <div class="examplenum">
-<a href="#example-163">Example 163</a>
+<a href="#example-164">Example 164</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">```ruby
@@ -6478,9 +6552,9 @@ end
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-164">
+<div class="example" id="example-165">
 <div class="examplenum">
-<a href="#example-164">Example 164</a>
+<a href="#example-165">Example 165</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">~~~~<span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="space"> </span>ruby<span class="space"> </span>startline=3<span class="space"> </span>$%@#$
@@ -6498,9 +6572,9 @@ end
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-165">
+<div class="example" id="example-166">
 <div class="examplenum">
-<a href="#example-165">Example 165</a>
+<a href="#example-166">Example 166</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">````;
@@ -6513,9 +6587,9 @@ end
 </div>
 </div>
 <p><a href="#info-string">Info strings</a> for backtick code blocks cannot contain backticks:</p>
-<div class="example" id="example-166">
+<div class="example" id="example-167">
 <div class="examplenum">
-<a href="#example-166">Example 166</a>
+<a href="#example-167">Example 167</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">```<span class="space"> </span>aa<span class="space"> </span>```
@@ -6529,9 +6603,9 @@ foo&lt;/p&gt;
 </div>
 </div>
 <p><a href="#info-string">Info strings</a> for tilde code blocks can contain backticks and tildes:</p>
-<div class="example" id="example-167">
+<div class="example" id="example-168">
 <div class="examplenum">
-<a href="#example-167">Example 167</a>
+<a href="#example-168">Example 168</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">~~~<span class="space"> </span>aa<span class="space"> </span>```<span class="space"> </span>~~~
@@ -6546,9 +6620,9 @@ foo
 </div>
 </div>
 <p>Closing code fences cannot have <a href="#info-string">info strings</a>:</p>
-<div class="example" id="example-168">
+<div class="example" id="example-169">
 <div class="examplenum">
-<a href="#example-168">Example 168</a>
+<a href="#example-169">Example 169</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">```
@@ -7086,9 +7160,9 @@ Some paragraph.
 <p>If you want to type poetry where every character is taken exactly literally,
 instead of being potentially interpreted as Markua formatting, you need to use
 a code block with a format of text for that:</p>
-<div class="example" id="example-169">
+<div class="example" id="example-170">
 <div class="examplenum">
-<a href="#example-169">Example 169</a>
+<a href="#example-170">Example 170</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">```text
@@ -7136,9 +7210,9 @@ defines a label which can be used in <a href="#reference-link">reference links</
 and reference-style <a href="#images">images</a> elsewhere in the document.  <a href="#link-reference-definitions">Link
 reference definitions</a> can come either before or after the links that use
 them.</p>
-<div class="example" id="example-170">
+<div class="example" id="example-171">
 <div class="examplenum">
-<a href="#example-170">Example 170</a>
+<a href="#example-171">Example 171</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[foo]:<span class="space"> </span>/url<span class="space"> </span>&quot;title&quot;
@@ -7151,9 +7225,9 @@ them.</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-171">
+<div class="example" id="example-172">
 <div class="examplenum">
-<a href="#example-171">Example 171</a>
+<a href="#example-172">Example 172</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown"><span class="space"> </span><span class="space"> </span><span class="space"> </span>[foo]:<span class="space"> </span>
@@ -7168,9 +7242,9 @@ them.</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-172">
+<div class="example" id="example-173">
 <div class="examplenum">
-<a href="#example-172">Example 172</a>
+<a href="#example-173">Example 173</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[Foo*bar\]]:my_(url)<span class="space"> </span>'title<span class="space"> </span>(with<span class="space"> </span>parens)'
@@ -7183,9 +7257,9 @@ them.</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-173">
+<div class="example" id="example-174">
 <div class="examplenum">
-<a href="#example-173">Example 173</a>
+<a href="#example-174">Example 174</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[Foo<span class="space"> </span>bar]:
@@ -7201,9 +7275,9 @@ them.</p>
 </div>
 </div>
 <p>The title may extend over multiple lines:</p>
-<div class="example" id="example-174">
+<div class="example" id="example-175">
 <div class="examplenum">
-<a href="#example-174">Example 174</a>
+<a href="#example-175">Example 175</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[foo]:<span class="space"> </span>/url<span class="space"> </span>'
@@ -7225,9 +7299,9 @@ line2
 </div>
 </div>
 <p>However, it may not contain a <a href="#blank-line">blank line</a>:</p>
-<div class="example" id="example-175">
+<div class="example" id="example-176">
 <div class="examplenum">
-<a href="#example-175">Example 175</a>
+<a href="#example-176">Example 176</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[foo]:<span class="space"> </span>/url<span class="space"> </span>'title
@@ -7245,9 +7319,9 @@ with<span class="space"> </span>blank<span class="space"> </span>line'
 </div>
 </div>
 <p>The title may be omitted:</p>
-<div class="example" id="example-176">
+<div class="example" id="example-177">
 <div class="examplenum">
-<a href="#example-176">Example 176</a>
+<a href="#example-177">Example 177</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[foo]:
@@ -7262,9 +7336,9 @@ with<span class="space"> </span>blank<span class="space"> </span>line'
 </div>
 </div>
 <p>The link destination may not be omitted:</p>
-<div class="example" id="example-177">
+<div class="example" id="example-178">
 <div class="examplenum">
-<a href="#example-177">Example 177</a>
+<a href="#example-178">Example 178</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[foo]:
@@ -7280,9 +7354,9 @@ with<span class="space"> </span>blank<span class="space"> </span>line'
 </div>
 <p>However, an empty link destination may be specified using
 angle brackets:</p>
-<div class="example" id="example-178">
+<div class="example" id="example-179">
 <div class="examplenum">
-<a href="#example-178">Example 178</a>
+<a href="#example-179">Example 179</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[foo]:<span class="space"> </span>&lt;&gt;
@@ -7297,9 +7371,9 @@ angle brackets:</p>
 </div>
 <p>The title must be separated from the link destination by
 spaces or tabs:</p>
-<div class="example" id="example-179">
+<div class="example" id="example-180">
 <div class="examplenum">
-<a href="#example-179">Example 179</a>
+<a href="#example-180">Example 180</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[foo]:<span class="space"> </span>&lt;bar&gt;(baz)
@@ -7315,9 +7389,9 @@ spaces or tabs:</p>
 </div>
 <p>Both title and destination can contain backslash escapes
 and literal backslashes:</p>
-<div class="example" id="example-180">
+<div class="example" id="example-181">
 <div class="examplenum">
-<a href="#example-180">Example 180</a>
+<a href="#example-181">Example 181</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[foo]:<span class="space"> </span>/url\bar\*baz<span class="space"> </span>&quot;foo\&quot;bar\baz&quot;
@@ -7331,9 +7405,9 @@ and literal backslashes:</p>
 </div>
 </div>
 <p>A link can come before its corresponding definition:</p>
-<div class="example" id="example-181">
+<div class="example" id="example-182">
 <div class="examplenum">
-<a href="#example-181">Example 181</a>
+<a href="#example-182">Example 182</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[foo]
@@ -7348,9 +7422,9 @@ and literal backslashes:</p>
 </div>
 <p>If there are several matching definitions, the first one takes
 precedence:</p>
-<div class="example" id="example-182">
+<div class="example" id="example-183">
 <div class="examplenum">
-<a href="#example-182">Example 182</a>
+<a href="#example-183">Example 183</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[foo]
@@ -7366,9 +7440,9 @@ precedence:</p>
 </div>
 <p>As noted in the section on <a href="#links">Links</a>, matching of labels is
 case-insensitive (see <a href="#matches">matches</a>).</p>
-<div class="example" id="example-183">
+<div class="example" id="example-184">
 <div class="examplenum">
-<a href="#example-183">Example 183</a>
+<a href="#example-184">Example 184</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[FOO]:<span class="space"> </span>/url
@@ -7381,9 +7455,9 @@ case-insensitive (see <a href="#matches">matches</a>).</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-184">
+<div class="example" id="example-185">
 <div class="examplenum">
-<a href="#example-184">Example 184</a>
+<a href="#example-185">Example 185</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[ΑΓΩ]:<span class="space"> </span>/φου
@@ -7401,9 +7475,9 @@ independent of whether the link reference it defines is
 used in the document.  Thus, for example, the following
 document contains just a link reference definition, and
 no visible content:</p>
-<div class="example" id="example-185">
+<div class="example" id="example-186">
 <div class="examplenum">
-<a href="#example-185">Example 185</a>
+<a href="#example-186">Example 186</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[foo]:<span class="space"> </span>/url
@@ -7414,9 +7488,9 @@ no visible content:</p>
 </div>
 </div>
 <p>Here is another one:</p>
-<div class="example" id="example-186">
+<div class="example" id="example-187">
 <div class="examplenum">
-<a href="#example-186">Example 186</a>
+<a href="#example-187">Example 187</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[
@@ -7432,9 +7506,9 @@ bar
 </div>
 <p>This is not a link reference definition, because there are
 characters other than spaces or tabs after the title:</p>
-<div class="example" id="example-187">
+<div class="example" id="example-188">
 <div class="examplenum">
-<a href="#example-187">Example 187</a>
+<a href="#example-188">Example 188</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[foo]:<span class="space"> </span>/url<span class="space"> </span>&quot;title&quot;<span class="space"> </span>ok
@@ -7446,9 +7520,9 @@ characters other than spaces or tabs after the title:</p>
 </div>
 </div>
 <p>This is a link reference definition, but it has no title:</p>
-<div class="example" id="example-188">
+<div class="example" id="example-189">
 <div class="examplenum">
-<a href="#example-188">Example 188</a>
+<a href="#example-189">Example 189</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[foo]:<span class="space"> </span>/url
@@ -7462,9 +7536,9 @@ characters other than spaces or tabs after the title:</p>
 </div>
 <p>This is not a link reference definition, because it is indented
 four spaces:</p>
-<div class="example" id="example-189">
+<div class="example" id="example-190">
 <div class="examplenum">
-<a href="#example-189">Example 189</a>
+<a href="#example-190">Example 190</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown"><span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="space"> </span>[foo]:<span class="space"> </span>/url<span class="space"> </span>&quot;title&quot;
@@ -7481,9 +7555,9 @@ four spaces:</p>
 </div>
 <p>This is not a link reference definition, because it occurs inside
 a code block:</p>
-<div class="example" id="example-190">
+<div class="example" id="example-191">
 <div class="examplenum">
-<a href="#example-190">Example 190</a>
+<a href="#example-191">Example 191</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">```
@@ -7501,9 +7575,9 @@ a code block:</p>
 </div>
 </div>
 <p>A <a href="#link-reference-definition">link reference definition</a> cannot interrupt a paragraph.</p>
-<div class="example" id="example-191">
+<div class="example" id="example-192">
 <div class="examplenum">
-<a href="#example-191">Example 191</a>
+<a href="#example-192">Example 192</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">Foo
@@ -7521,9 +7595,9 @@ a code block:</p>
 </div>
 <p>However, it can directly follow other block elements, such as headings
 and thematic breaks, and it need not be followed by a blank line.</p>
-<div class="example" id="example-192">
+<div class="example" id="example-193">
 <div class="examplenum">
-<a href="#example-192">Example 192</a>
+<a href="#example-193">Example 193</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">#<span class="space"> </span>[Foo]
@@ -7539,9 +7613,9 @@ and thematic breaks, and it need not be followed by a blank line.</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-193">
+<div class="example" id="example-194">
 <div class="examplenum">
-<a href="#example-193">Example 193</a>
+<a href="#example-194">Example 194</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[foo]:<span class="space"> </span>/url
@@ -7556,9 +7630,9 @@ bar
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-194">
+<div class="example" id="example-195">
 <div class="examplenum">
-<a href="#example-194">Example 194</a>
+<a href="#example-195">Example 195</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[foo]:<span class="space"> </span>/url
@@ -7574,9 +7648,9 @@ bar
 </div>
 <p>Several <a href="#link-reference-definitions">link reference definitions</a>
 can occur one after another, without intervening blank lines.</p>
-<div class="example" id="example-195">
+<div class="example" id="example-196">
 <div class="examplenum">
-<a href="#example-195">Example 195</a>
+<a href="#example-196">Example 196</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[foo]:<span class="space"> </span>/foo-url<span class="space"> </span>&quot;foo&quot;
@@ -7600,9 +7674,9 @@ can occur one after another, without intervening blank lines.</p>
 inside block containers, like lists and block quotations.  They
 affect the entire document, not just the container in which they
 are defined:</p>
-<div class="example" id="example-196">
+<div class="example" id="example-197">
 <div class="examplenum">
-<a href="#example-196">Example 196</a>
+<a href="#example-197">Example 197</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[foo]
@@ -7627,9 +7701,9 @@ paragraph’s raw content as inlines.  The paragraph’s raw content
 is formed by concatenating the lines and removing initial and final
 spaces or tabs.</p>
 <p>A simple example with two paragraphs:</p>
-<div class="example" id="example-197">
+<div class="example" id="example-198">
 <div class="examplenum">
-<a href="#example-197">Example 197</a>
+<a href="#example-198">Example 198</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">aaa
@@ -7644,9 +7718,9 @@ bbb
 </div>
 </div>
 <p>Paragraphs can contain multiple lines, but no blank lines:</p>
-<div class="example" id="example-198">
+<div class="example" id="example-199">
 <div class="examplenum">
-<a href="#example-198">Example 198</a>
+<a href="#example-199">Example 199</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">aaa
@@ -7665,9 +7739,9 @@ ddd&lt;/p&gt;
 </div>
 </div>
 <p>Multiple blank lines between paragraphs have no effect:</p>
-<div class="example" id="example-199">
+<div class="example" id="example-200">
 <div class="examplenum">
-<a href="#example-199">Example 199</a>
+<a href="#example-200">Example 200</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">aaa
@@ -7683,9 +7757,9 @@ bbb
 </div>
 </div>
 <p>Leading spaces or tabs are skipped:</p>
-<div class="example" id="example-200">
+<div class="example" id="example-201">
 <div class="examplenum">
-<a href="#example-200">Example 200</a>
+<a href="#example-201">Example 201</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown"><span class="space"> </span><span class="space"> </span>aaa
@@ -7700,9 +7774,9 @@ bbb&lt;/p&gt;
 </div>
 <p>Lines after the first may be indented any amount, since indented
 code blocks cannot interrupt paragraphs.</p>
-<div class="example" id="example-201">
+<div class="example" id="example-202">
 <div class="examplenum">
-<a href="#example-201">Example 201</a>
+<a href="#example-202">Example 202</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">aaa
@@ -7719,9 +7793,9 @@ ccc&lt;/p&gt;
 </div>
 <p>However, the first line may be preceded by up to three spaces of indentation.
 Four spaces of indentation is too many:</p>
-<div class="example" id="example-202">
+<div class="example" id="example-203">
 <div class="examplenum">
-<a href="#example-202">Example 202</a>
+<a href="#example-203">Example 203</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown"><span class="space"> </span><span class="space"> </span><span class="space"> </span>aaa
@@ -7734,9 +7808,9 @@ bbb&lt;/p&gt;
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-203">
+<div class="example" id="example-204">
 <div class="examplenum">
-<a href="#example-203">Example 203</a>
+<a href="#example-204">Example 204</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown"><span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="space"> </span>aaa
@@ -7753,9 +7827,9 @@ bbb
 <p>Final spaces or tabs are stripped before inline parsing, so a paragraph
 that ends with two or more spaces will not end with a <a href="#hard-line-break">hard line
 break</a>:</p>
-<div class="example" id="example-204">
+<div class="example" id="example-205">
 <div class="examplenum">
-<a href="#example-204">Example 204</a>
+<a href="#example-205">Example 205</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">aaa<span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="space"> </span>
@@ -7775,9 +7849,9 @@ bbb&lt;/p&gt;
 except for the role they play in determining whether a <a href="#list">list</a>
 is <a href="#tight">tight</a> or <a href="#loose">loose</a>.</p>
 <p>Blank lines at the beginning and end of the document are also ignored.</p>
-<div class="example" id="example-205">
+<div class="example" id="example-206">
 <div class="examplenum">
-<a href="#example-205">Example 205</a>
+<a href="#example-206">Example 206</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown"><span class="space"> </span><span class="space"> </span>
@@ -7813,9 +7887,9 @@ be inserted in a table.</p>
 <p>The <a id="delimiter-row" href="#delimiter-row" class="definition">delimiter row</a> consists of cells whose only content are hyphens (<code>-</code>),
 and optionally, a leading or trailing colon (<code>:</code>), or both, to indicate left,
 right, or center alignment respectively.</p>
-<div class="example" id="example-206">
+<div class="example" id="example-207">
 <div class="examplenum">
-<a href="#example-206">Example 206</a>
+<a href="#example-207">Example 207</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">|<span class="space"> </span>foo<span class="space"> </span>|<span class="space"> </span>bar<span class="space"> </span>|
@@ -7843,9 +7917,9 @@ right, or center alignment respectively.</p>
 </div>
 <p>Cells in one column don’t need to match length, though it’s easier to read if
 they are. Likewise, use of leading and trailing pipes may be inconsistent:</p>
-<div class="example" id="example-207">
+<div class="example" id="example-208">
 <div class="examplenum">
-<a href="#example-207">Example 207</a>
+<a href="#example-208">Example 208</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">|<span class="space"> </span>abc<span class="space"> </span>|<span class="space"> </span>defghi<span class="space"> </span>|
@@ -7873,9 +7947,9 @@ bar<span class="space"> </span>|<span class="space"> </span>baz
 </div>
 <p>Include a pipe in a cell’s content by escaping it, including inside other
 inline spans:</p>
-<div class="example" id="example-208">
+<div class="example" id="example-209">
 <div class="examplenum">
-<a href="#example-208">Example 208</a>
+<a href="#example-209">Example 209</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">|<span class="space"> </span>f\|oo<span class="space"> </span><span class="space"> </span>|
@@ -7905,9 +7979,9 @@ inline spans:</p>
 </div>
 <p>The table is broken at the first empty line, or beginning of another
 block-level structure:</p>
-<div class="example" id="example-209">
+<div class="example" id="example-210">
 <div class="examplenum">
-<a href="#example-209">Example 209</a>
+<a href="#example-210">Example 210</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">|<span class="space"> </span>abc<span class="space"> </span>|<span class="space"> </span>def<span class="space"> </span>|
@@ -7937,9 +8011,9 @@ block-level structure:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-210">
+<div class="example" id="example-211">
 <div class="examplenum">
-<a href="#example-210">Example 210</a>
+<a href="#example-211">Example 211</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">|<span class="space"> </span>abc<span class="space"> </span>|<span class="space"> </span>def<span class="space"> </span>|
@@ -7975,9 +8049,9 @@ bar
 </div>
 <p>The header row must match the <a href="#delimiter-row">delimiter row</a> in the number of cells.  If not,
 a table will not be recognized:</p>
-<div class="example" id="example-211">
+<div class="example" id="example-212">
 <div class="examplenum">
-<a href="#example-211">Example 211</a>
+<a href="#example-212">Example 212</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">|<span class="space"> </span>abc<span class="space"> </span>|<span class="space"> </span>def<span class="space"> </span>|
@@ -7995,9 +8069,9 @@ a table will not be recognized:</p>
 <p>The remainder of the table’s rows may vary in the number of cells.  If there
 are a number of cells fewer than the number of cells in the header row, empty
 cells are inserted.  If there are greater, the excess is ignored:</p>
-<div class="example" id="example-212">
+<div class="example" id="example-213">
 <div class="examplenum">
-<a href="#example-212">Example 212</a>
+<a href="#example-213">Example 213</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">|<span class="space"> </span>abc<span class="space"> </span>|<span class="space"> </span>def<span class="space"> </span>|
@@ -8029,9 +8103,9 @@ cells are inserted.  If there are greater, the excess is ignored:</p>
 </div>
 </div>
 <p>If there are no rows in the body, no <code>&lt;tbody&gt;</code> is generated in HTML output:</p>
-<div class="example" id="example-213">
+<div class="example" id="example-214">
 <div class="examplenum">
-<a href="#example-213">Example 213</a>
+<a href="#example-214">Example 214</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">|<span class="space"> </span>abc<span class="space"> </span>|<span class="space"> </span>def<span class="space"> </span>|
@@ -8169,9 +8243,9 @@ followed by a percentage sign (%). The quotes are optional. So, you can say
 <p>The examples below assume that a table which looks like the following (from the
 GFM table example above) is defined in a file called <code>census.tbl</code> (real census
 data would be too long for a good example):</p>
-<div class="example" id="example-214">
+<div class="example" id="example-215">
 <div class="examplenum">
-<a href="#example-214">Example 214</a>
+<a href="#example-215">Example 215</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">|<span class="space"> </span>foo<span class="space"> </span>|<span class="space"> </span>bar<span class="space"> </span>|
@@ -8199,9 +8273,9 @@ data would be too long for a good example):</p>
 </div>
 <p>With this table above defined in a file which is available at a local
 resource location, the following example results:</p>
-<div class="example" id="example-215">
+<div class="example" id="example-216">
 <div class="examplenum">
-<a href="#example-215">Example 215</a>
+<a href="#example-216">Example 216</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">![](census.tbl<span class="space"> </span>&quot;Canadian<span class="space"> </span>Census<span class="space"> </span>Data&quot;)
@@ -8230,9 +8304,9 @@ resource location, the following example results:</p>
 </div>
 <p>With this table above defined in a file which is available at a given web
 resource location, the identical example results:</p>
-<div class="example" id="example-216">
+<div class="example" id="example-217">
 <div class="examplenum">
-<a href="#example-216">Example 216</a>
+<a href="#example-217">Example 217</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">![](https://markua.com/census.tbl<span class="space"> </span>&quot;Canadian<span class="space"> </span>Census<span class="space"> </span>Data&quot;)
@@ -8395,9 +8469,9 @@ quotes</a> in a row unless there is a <a href="#blank-line">blank line</a> betwe
 </ol>
 <p>Nothing else counts as a <a href="#block-quotes">block quote</a>.</p>
 <p>Here is a simple example:</p>
-<div class="example" id="example-217">
+<div class="example" id="example-218">
 <div class="examplenum">
-<a href="#example-217">Example 217</a>
+<a href="#example-218">Example 218</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">&gt;<span class="space"> </span>#<span class="space"> </span>Foo
@@ -8415,9 +8489,9 @@ baz&lt;/p&gt;
 </div>
 </div>
 <p>The space or tab after the <code>&gt;</code> characters can be omitted:</p>
-<div class="example" id="example-218">
+<div class="example" id="example-219">
 <div class="examplenum">
-<a href="#example-218">Example 218</a>
+<a href="#example-219">Example 219</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">&gt;#<span class="space"> </span>Foo
@@ -8435,9 +8509,9 @@ baz&lt;/p&gt;
 </div>
 </div>
 <p>The <code>&gt;</code> characters can be preceded by up to three spaces of indentation:</p>
-<div class="example" id="example-219">
+<div class="example" id="example-220">
 <div class="examplenum">
-<a href="#example-219">Example 219</a>
+<a href="#example-220">Example 220</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown"><span class="space"> </span><span class="space"> </span><span class="space"> </span>&gt;<span class="space"> </span>#<span class="space"> </span>Foo
@@ -8455,9 +8529,9 @@ baz&lt;/p&gt;
 </div>
 </div>
 <p>Four spaces of indentation is too many:</p>
-<div class="example" id="example-220">
+<div class="example" id="example-221">
 <div class="examplenum">
-<a href="#example-220">Example 220</a>
+<a href="#example-221">Example 221</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown"><span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="space"> </span>&gt;<span class="space"> </span>#<span class="space"> </span>Foo
@@ -8475,9 +8549,9 @@ baz&lt;/p&gt;
 </div>
 <p>The Laziness clause allows us to omit the <code>&gt;</code> before
 <a href="#paragraph-continuation-text">paragraph continuation text</a>:</p>
-<div class="example" id="example-221">
+<div class="example" id="example-222">
 <div class="examplenum">
-<a href="#example-221">Example 221</a>
+<a href="#example-222">Example 222</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">&gt;<span class="space"> </span>#<span class="space"> </span>Foo
@@ -8496,9 +8570,9 @@ baz&lt;/p&gt;
 </div>
 <p>A block quote can contain some lazy and some non-lazy
 continuation lines:</p>
-<div class="example" id="example-222">
+<div class="example" id="example-223">
 <div class="examplenum">
-<a href="#example-222">Example 222</a>
+<a href="#example-223">Example 223</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">&gt;<span class="space"> </span>bar
@@ -8522,9 +8596,9 @@ For example, the <code>&gt; </code> cannot be omitted in the second line of</p>
 &gt; ---
 </code></pre>
 <p>without changing the meaning:</p>
-<div class="example" id="example-223">
+<div class="example" id="example-224">
 <div class="examplenum">
-<a href="#example-223">Example 223</a>
+<a href="#example-224">Example 224</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">&gt;<span class="space"> </span>foo
@@ -8544,9 +8618,9 @@ For example, the <code>&gt; </code> cannot be omitted in the second line of</p>
 &gt; - bar
 </code></pre>
 <p>then the block quote ends after the first line:</p>
-<div class="example" id="example-224">
+<div class="example" id="example-225">
 <div class="examplenum">
-<a href="#example-224">Example 224</a>
+<a href="#example-225">Example 225</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">&gt;<span class="space"> </span>-<span class="space"> </span>foo
@@ -8567,9 +8641,9 @@ For example, the <code>&gt; </code> cannot be omitted in the second line of</p>
 </div>
 <p>For the same reason, we can’t omit the <code>&gt; </code> in front of
 subsequent lines of an indented or fenced code block:</p>
-<div class="example" id="example-225">
+<div class="example" id="example-226">
 <div class="examplenum">
-<a href="#example-225">Example 225</a>
+<a href="#example-226">Example 226</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">&gt;<span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="space"> </span>foo
@@ -8586,9 +8660,9 @@ subsequent lines of an indented or fenced code block:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-226">
+<div class="example" id="example-227">
 <div class="examplenum">
-<a href="#example-226">Example 226</a>
+<a href="#example-227">Example 227</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">&gt;<span class="space"> </span>```
@@ -8607,9 +8681,9 @@ foo
 </div>
 <p>Note that in the following case, we have a <a href="#lazy-continuation-line">lazy
 continuation line</a>:</p>
-<div class="example" id="example-227">
+<div class="example" id="example-228">
 <div class="examplenum">
-<a href="#example-227">Example 227</a>
+<a href="#example-228">Example 228</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">&gt;<span class="space"> </span>foo
@@ -8632,9 +8706,9 @@ continuation line</a>:</p>
 be an indented code block because indented code blocks cannot
 interrupt paragraphs, so it is <a href="#paragraph-continuation-text">paragraph continuation text</a>.</p>
 <p>A block quote can be empty:</p>
-<div class="example" id="example-228">
+<div class="example" id="example-229">
 <div class="examplenum">
-<a href="#example-228">Example 228</a>
+<a href="#example-229">Example 229</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">&gt;
@@ -8646,9 +8720,9 @@ interrupt paragraphs, so it is <a href="#paragraph-continuation-text">paragraph 
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-229">
+<div class="example" id="example-230">
 <div class="examplenum">
-<a href="#example-229">Example 229</a>
+<a href="#example-230">Example 230</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">&gt;
@@ -8663,9 +8737,9 @@ interrupt paragraphs, so it is <a href="#paragraph-continuation-text">paragraph 
 </div>
 </div>
 <p>A block quote can have initial or final blank lines:</p>
-<div class="example" id="example-230">
+<div class="example" id="example-231">
 <div class="examplenum">
-<a href="#example-230">Example 230</a>
+<a href="#example-231">Example 231</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">&gt;
@@ -8681,9 +8755,9 @@ interrupt paragraphs, so it is <a href="#paragraph-continuation-text">paragraph 
 </div>
 </div>
 <p>A blank line always separates block quotes:</p>
-<div class="example" id="example-231">
+<div class="example" id="example-232">
 <div class="examplenum">
-<a href="#example-231">Example 231</a>
+<a href="#example-232">Example 232</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">&gt;<span class="space"> </span>foo
@@ -8707,9 +8781,9 @@ with two paragraphs.  But it seems better to allow the author to decide
 whether two block quotes or one are wanted.)</p>
 <p>Consecutiveness means that if we put these block quotes together,
 we get a single block quote:</p>
-<div class="example" id="example-232">
+<div class="example" id="example-233">
 <div class="examplenum">
-<a href="#example-232">Example 232</a>
+<a href="#example-233">Example 233</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">&gt;<span class="space"> </span>foo
@@ -8725,9 +8799,9 @@ bar&lt;/p&gt;
 </div>
 </div>
 <p>To get a block quote with two paragraphs, use:</p>
-<div class="example" id="example-233">
+<div class="example" id="example-234">
 <div class="examplenum">
-<a href="#example-233">Example 233</a>
+<a href="#example-234">Example 234</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">&gt;<span class="space"> </span>foo
@@ -8744,9 +8818,9 @@ bar&lt;/p&gt;
 </div>
 </div>
 <p>Block quotes can interrupt paragraphs:</p>
-<div class="example" id="example-234">
+<div class="example" id="example-235">
 <div class="examplenum">
-<a href="#example-234">Example 234</a>
+<a href="#example-235">Example 235</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">foo
@@ -8763,9 +8837,9 @@ bar&lt;/p&gt;
 </div>
 <p>In general, blank lines are not needed before or after block
 quotes:</p>
-<div class="example" id="example-235">
+<div class="example" id="example-236">
 <div class="examplenum">
-<a href="#example-235">Example 235</a>
+<a href="#example-236">Example 236</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">&gt;<span class="space"> </span>aaa
@@ -8786,9 +8860,9 @@ quotes:</p>
 </div>
 <p>However, because of laziness, a blank line is needed between
 a block quote and a following paragraph:</p>
-<div class="example" id="example-236">
+<div class="example" id="example-237">
 <div class="examplenum">
-<a href="#example-236">Example 236</a>
+<a href="#example-237">Example 237</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">&gt;<span class="space"> </span>bar
@@ -8803,9 +8877,9 @@ baz&lt;/p&gt;
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-237">
+<div class="example" id="example-238">
 <div class="examplenum">
-<a href="#example-237">Example 237</a>
+<a href="#example-238">Example 238</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">&gt;<span class="space"> </span>bar
@@ -8821,9 +8895,9 @@ baz
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-238">
+<div class="example" id="example-239">
 <div class="examplenum">
-<a href="#example-238">Example 238</a>
+<a href="#example-239">Example 239</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">&gt;<span class="space"> </span>bar
@@ -8842,9 +8916,9 @@ baz
 <p>It is a consequence of the Laziness rule that any number
 of initial <code>&gt;</code>s may be omitted on a continuation line of a
 nested block quote:</p>
-<div class="example" id="example-239">
+<div class="example" id="example-240">
 <div class="examplenum">
-<a href="#example-239">Example 239</a>
+<a href="#example-240">Example 240</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">&gt;<span class="space"> </span>&gt;<span class="space"> </span>&gt;<span class="space"> </span>foo
@@ -8863,9 +8937,9 @@ bar&lt;/p&gt;
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-240">
+<div class="example" id="example-241">
 <div class="examplenum">
-<a href="#example-240">Example 240</a>
+<a href="#example-241">Example 241</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">&gt;&gt;&gt;<span class="space"> </span>foo
@@ -8890,9 +8964,9 @@ baz&lt;/p&gt;
 remember that the <a href="#block-quote-marker">block quote marker</a> includes
 both the <code>&gt;</code> and a following space of indentation.  So <em>five spaces</em> are needed
 after the <code>&gt;</code>:</p>
-<div class="example" id="example-241">
+<div class="example" id="example-242">
 <div class="examplenum">
-<a href="#example-241">Example 241</a>
+<a href="#example-242">Example 242</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">&gt;<span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="space"> </span>code
@@ -8926,9 +9000,9 @@ really long quotes.</p>
 <p>Like figures and tables, blockquotes can be inserted in the middle of a
 paragraph or as a sibling of it.</p>
 <p>These are the two ways to make block quotes in Markua:</p>
-<div class="example" id="example-242">
+<div class="example" id="example-243">
 <div class="examplenum">
-<a href="#example-242">Example 242</a>
+<a href="#example-243">Example 243</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">This<span class="space"> </span>is<span class="space"> </span>the<span class="space"> </span>first<span class="space"> </span>paragraph.
@@ -9005,9 +9079,9 @@ that line is not a list item.</li>
 </li>
 </ol>
 <p>For example, let <em>Ls</em> be the lines</p>
-<div class="example" id="example-243">
+<div class="example" id="example-244">
 <div class="examplenum">
-<a href="#example-243">Example 243</a>
+<a href="#example-244">Example 244</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">A<span class="space"> </span>paragraph
@@ -9032,9 +9106,9 @@ with<span class="space"> </span>two<span class="space"> </span>lines.&lt;/p&gt;
 <p>And let <em>M</em> be the marker <code>1.</code>, and <em>N</em> = 2.  Then rule #1 says
 that the following is an ordered list item with start number 1,
 and the same contents as <em>Ls</em>:</p>
-<div class="example" id="example-244">
+<div class="example" id="example-245">
 <div class="examplenum">
-<a href="#example-244">Example 244</a>
+<a href="#example-245">Example 245</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">1.<span class="space"> </span><span class="space"> </span>A<span class="space"> </span>paragraph
@@ -9069,9 +9143,9 @@ must be indented five spaces in order to fall under the list
 item.</p>
 <p>Here are some examples showing how far content must be indented to be
 put under the list item:</p>
-<div class="example" id="example-245">
+<div class="example" id="example-246">
 <div class="examplenum">
-<a href="#example-245">Example 245</a>
+<a href="#example-246">Example 246</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">-<span class="space"> </span>one
@@ -9087,9 +9161,9 @@ put under the list item:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-246">
+<div class="example" id="example-247">
 <div class="examplenum">
-<a href="#example-246">Example 246</a>
+<a href="#example-247">Example 247</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">-<span class="space"> </span>one
@@ -9107,9 +9181,9 @@ put under the list item:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-247">
+<div class="example" id="example-248">
 <div class="examplenum">
-<a href="#example-247">Example 247</a>
+<a href="#example-248">Example 248</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown"><span class="space"> </span>-<span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="space"> </span>one
@@ -9126,9 +9200,9 @@ put under the list item:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-248">
+<div class="example" id="example-249">
 <div class="examplenum">
-<a href="#example-248">Example 248</a>
+<a href="#example-249">Example 249</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown"><span class="space"> </span>-<span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="space"> </span>one
@@ -9153,9 +9227,9 @@ The spaces of indentation after the list marker determine how much relative
 indentation is needed.  Which column this indentation reaches will depend on
 how the list item is embedded in other constructions, as shown by
 this example:</p>
-<div class="example" id="example-249">
+<div class="example" id="example-250">
 <div class="examplenum">
-<a href="#example-249">Example 249</a>
+<a href="#example-250">Example 250</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown"><span class="space"> </span><span class="space"> </span><span class="space"> </span>&gt;<span class="space"> </span>&gt;<span class="space"> </span>1.<span class="space"> </span><span class="space"> </span>one
@@ -9184,9 +9258,9 @@ sufficient indentation after the last containing blockquote marker.</p>
 occurs far to the right of the initial text of the list item, <code>one</code>, but
 it is not considered part of the list item, because it is not indented
 far enough past the blockquote marker:</p>
-<div class="example" id="example-250">
+<div class="example" id="example-251">
 <div class="examplenum">
-<a href="#example-250">Example 250</a>
+<a href="#example-251">Example 251</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">&gt;&gt;-<span class="space"> </span>one
@@ -9208,9 +9282,9 @@ far enough past the blockquote marker:</p>
 </div>
 <p>Note that at least one space or tab is needed between the list marker and
 any following content, so these are not list items:</p>
-<div class="example" id="example-251">
+<div class="example" id="example-252">
 <div class="examplenum">
-<a href="#example-251">Example 251</a>
+<a href="#example-252">Example 252</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">-one
@@ -9226,9 +9300,9 @@ any following content, so these are not list items:</p>
 </div>
 <p>A list item may contain blocks that are separated by more than
 one blank line.</p>
-<div class="example" id="example-252">
+<div class="example" id="example-253">
 <div class="examplenum">
-<a href="#example-252">Example 252</a>
+<a href="#example-253">Example 253</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">-<span class="space"> </span>foo
@@ -9248,9 +9322,9 @@ one blank line.</p>
 </div>
 </div>
 <p>A list item may contain any kind of block:</p>
-<div class="example" id="example-253">
+<div class="example" id="example-254">
 <div class="examplenum">
-<a href="#example-253">Example 253</a>
+<a href="#example-254">Example 254</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">1.<span class="space"> </span><span class="space"> </span>foo
@@ -9281,9 +9355,9 @@ one blank line.</p>
 </div>
 <p>A list item that contains an indented code block will preserve
 empty lines within the code block verbatim.</p>
-<div class="example" id="example-254">
+<div class="example" id="example-255">
 <div class="examplenum">
-<a href="#example-254">Example 254</a>
+<a href="#example-255">Example 255</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">-<span class="space"> </span>Foo
@@ -9309,9 +9383,9 @@ baz
 </div>
 </div>
 <p>Note that ordered list start numbers must be nine digits or less:</p>
-<div class="example" id="example-255">
+<div class="example" id="example-256">
 <div class="examplenum">
-<a href="#example-255">Example 255</a>
+<a href="#example-256">Example 256</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">123456789.<span class="space"> </span>ok
@@ -9324,9 +9398,9 @@ baz
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-256">
+<div class="example" id="example-257">
 <div class="examplenum">
-<a href="#example-256">Example 256</a>
+<a href="#example-257">Example 257</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">1234567890.<span class="space"> </span>not<span class="space"> </span>ok
@@ -9338,9 +9412,9 @@ baz
 </div>
 </div>
 <p>A start number may begin with 0s:</p>
-<div class="example" id="example-257">
+<div class="example" id="example-258">
 <div class="examplenum">
-<a href="#example-257">Example 257</a>
+<a href="#example-258">Example 258</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">0.<span class="space"> </span>ok
@@ -9353,9 +9427,9 @@ baz
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-258">
+<div class="example" id="example-259">
 <div class="examplenum">
-<a href="#example-258">Example 258</a>
+<a href="#example-259">Example 259</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">003.<span class="space"> </span>ok
@@ -9369,9 +9443,9 @@ baz
 </div>
 </div>
 <p>A start number may not be negative:</p>
-<div class="example" id="example-259">
+<div class="example" id="example-260">
 <div class="examplenum">
-<a href="#example-259">Example 259</a>
+<a href="#example-260">Example 260</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">-1.<span class="space"> </span>not<span class="space"> </span>ok
@@ -9397,9 +9471,9 @@ start number, based on the ordered list marker.</li>
 <p>An indented code block will have to be preceded by four spaces of indentation
 beyond the edge of the region where text will be included in the list item.
 In the following case that is 6 spaces:</p>
-<div class="example" id="example-260">
+<div class="example" id="example-261">
 <div class="examplenum">
-<a href="#example-260">Example 260</a>
+<a href="#example-261">Example 261</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">-<span class="space"> </span>foo
@@ -9419,9 +9493,9 @@ In the following case that is 6 spaces:</p>
 </div>
 </div>
 <p>And in this case it is 11 spaces:</p>
-<div class="example" id="example-261">
+<div class="example" id="example-262">
 <div class="examplenum">
-<a href="#example-261">Example 261</a>
+<a href="#example-262">Example 262</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown"><span class="space"> </span><span class="space"> </span>10.<span class="space"> </span><span class="space"> </span>foo
@@ -9443,9 +9517,9 @@ In the following case that is 6 spaces:</p>
 <p>If the <em>first</em> block in the list item is an indented code block,
 then by rule #2, the contents must be preceded by <em>one</em> space of indentation
 after the list marker:</p>
-<div class="example" id="example-262">
+<div class="example" id="example-263">
 <div class="examplenum">
-<a href="#example-262">Example 262</a>
+<a href="#example-263">Example 263</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown"><span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="space"> </span>indented<span class="space"> </span>code
@@ -9464,9 +9538,9 @@ paragraph
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-263">
+<div class="example" id="example-264">
 <div class="examplenum">
-<a href="#example-263">Example 263</a>
+<a href="#example-264">Example 264</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">1.<span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="space"> </span>indented<span class="space"> </span>code
@@ -9491,9 +9565,9 @@ paragraph
 </div>
 <p>Note that an additional space of indentation is interpreted as space
 inside the code block:</p>
-<div class="example" id="example-264">
+<div class="example" id="example-265">
 <div class="examplenum">
-<a href="#example-264">Example 264</a>
+<a href="#example-265">Example 265</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">1.<span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="space"> </span>indented<span class="space"> </span>code
@@ -9523,9 +9597,9 @@ they begin with an indented code
 block.  In a case like the following, where the first block begins with
 three spaces of indentation, the rules do not allow us to form a list item by
 indenting the whole thing and prepending a list marker:</p>
-<div class="example" id="example-265">
+<div class="example" id="example-266">
 <div class="examplenum">
-<a href="#example-265">Example 265</a>
+<a href="#example-266">Example 266</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown"><span class="space"> </span><span class="space"> </span><span class="space"> </span>foo
@@ -9539,9 +9613,9 @@ bar
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-266">
+<div class="example" id="example-267">
 <div class="examplenum">
-<a href="#example-266">Example 266</a>
+<a href="#example-267">Example 267</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">-<span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="space"> </span>foo
@@ -9561,9 +9635,9 @@ bar
 three spaces of indentation, the indentation can always be removed without
 a change in interpretation, allowing rule #1 to be applied.  So, in
 the above case:</p>
-<div class="example" id="example-267">
+<div class="example" id="example-268">
 <div class="examplenum">
-<a href="#example-267">Example 267</a>
+<a href="#example-268">Example 268</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">-<span class="space"> </span><span class="space"> </span>foo
@@ -9594,9 +9668,9 @@ marker.  If the list item is ordered, then it is also assigned a
 start number, based on the ordered list marker.</li>
 </ol>
 <p>Here are some list items that start with a blank line but are not empty:</p>
-<div class="example" id="example-268">
+<div class="example" id="example-269">
 <div class="examplenum">
-<a href="#example-268">Example 268</a>
+<a href="#example-269">Example 269</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">-
@@ -9626,9 +9700,9 @@ start number, based on the ordered list marker.</li>
 </div>
 <p>When the list item starts with a blank line, the number of spaces
 following the list marker doesn’t change the required indentation:</p>
-<div class="example" id="example-269">
+<div class="example" id="example-270">
 <div class="examplenum">
-<a href="#example-269">Example 269</a>
+<a href="#example-270">Example 270</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">-<span class="space"> </span><span class="space"> </span><span class="space"> </span>
@@ -9645,9 +9719,9 @@ following the list marker doesn’t change the required indentation:</p>
 <p>A list item can begin with at most one blank line.
 In the following example, <code>foo</code> is not part of the list
 item:</p>
-<div class="example" id="example-270">
+<div class="example" id="example-271">
 <div class="examplenum">
-<a href="#example-270">Example 270</a>
+<a href="#example-271">Example 271</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">-
@@ -9664,9 +9738,9 @@ item:</p>
 </div>
 </div>
 <p>Here is an empty bullet list item:</p>
-<div class="example" id="example-271">
+<div class="example" id="example-272">
 <div class="examplenum">
-<a href="#example-271">Example 271</a>
+<a href="#example-272">Example 272</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">-<span class="space"> </span>foo
@@ -9684,9 +9758,9 @@ item:</p>
 </div>
 </div>
 <p>It does not matter whether there are spaces or tabs following the <a href="#list-marker">list marker</a>:</p>
-<div class="example" id="example-272">
+<div class="example" id="example-273">
 <div class="examplenum">
-<a href="#example-272">Example 272</a>
+<a href="#example-273">Example 273</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">-<span class="space"> </span>foo
@@ -9704,9 +9778,9 @@ item:</p>
 </div>
 </div>
 <p>Here is an empty ordered list item:</p>
-<div class="example" id="example-273">
+<div class="example" id="example-274">
 <div class="examplenum">
-<a href="#example-273">Example 273</a>
+<a href="#example-274">Example 274</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">1.<span class="space"> </span>foo
@@ -9724,9 +9798,9 @@ item:</p>
 </div>
 </div>
 <p>A list may start or end with an empty list item:</p>
-<div class="example" id="example-274">
+<div class="example" id="example-275">
 <div class="examplenum">
-<a href="#example-274">Example 274</a>
+<a href="#example-275">Example 275</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">*
@@ -9740,9 +9814,9 @@ item:</p>
 </div>
 </div>
 <p>However, an empty list item cannot interrupt a paragraph:</p>
-<div class="example" id="example-275">
+<div class="example" id="example-276">
 <div class="examplenum">
-<a href="#example-275">Example 275</a>
+<a href="#example-276">Example 276</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">foo
@@ -9768,9 +9842,9 @@ constitutes a list item with the same contents and attributes.  If a line is
 empty, then it need not be indented.</li>
 </ol>
 <p>Indented one space:</p>
-<div class="example" id="example-276">
+<div class="example" id="example-277">
 <div class="examplenum">
-<a href="#example-276">Example 276</a>
+<a href="#example-277">Example 277</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown"><span class="space"> </span>1.<span class="space"> </span><span class="space"> </span>A<span class="space"> </span>paragraph
@@ -9797,9 +9871,9 @@ with<span class="space"> </span>two<span class="space"> </span>lines.&lt;/p&gt;
 </div>
 </div>
 <p>Indented two spaces:</p>
-<div class="example" id="example-277">
+<div class="example" id="example-278">
 <div class="examplenum">
-<a href="#example-277">Example 277</a>
+<a href="#example-278">Example 278</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown"><span class="space"> </span><span class="space"> </span>1.<span class="space"> </span><span class="space"> </span>A<span class="space"> </span>paragraph
@@ -9826,9 +9900,9 @@ with<span class="space"> </span>two<span class="space"> </span>lines.&lt;/p&gt;
 </div>
 </div>
 <p>Indented three spaces:</p>
-<div class="example" id="example-278">
+<div class="example" id="example-279">
 <div class="examplenum">
-<a href="#example-278">Example 278</a>
+<a href="#example-279">Example 279</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown"><span class="space"> </span><span class="space"> </span><span class="space"> </span>1.<span class="space"> </span><span class="space"> </span>A<span class="space"> </span>paragraph
@@ -9855,9 +9929,9 @@ with<span class="space"> </span>two<span class="space"> </span>lines.&lt;/p&gt;
 </div>
 </div>
 <p>Four spaces indent gives a code block:</p>
-<div class="example" id="example-279">
+<div class="example" id="example-280">
 <div class="examplenum">
-<a href="#example-279">Example 279</a>
+<a href="#example-280">Example 280</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown"><span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="space"> </span>1.<span class="space"> </span><span class="space"> </span>A<span class="space"> </span>paragraph
@@ -9890,9 +9964,9 @@ lines are called
 <a id="lazy-continuation-line" href="#lazy-continuation-line" class="definition">lazy continuation line</a>s.</li>
 </ol>
 <p>Here is an example with <a href="#lazy-continuation-line">lazy continuation lines</a>:</p>
-<div class="example" id="example-280">
+<div class="example" id="example-281">
 <div class="examplenum">
-<a href="#example-280">Example 280</a>
+<a href="#example-281">Example 281</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown"><span class="space"> </span><span class="space"> </span>1.<span class="space"> </span><span class="space"> </span>A<span class="space"> </span>paragraph
@@ -9919,9 +9993,9 @@ with<span class="space"> </span>two<span class="space"> </span>lines.&lt;/p&gt;
 </div>
 </div>
 <p>Indentation can be partially deleted:</p>
-<div class="example" id="example-281">
+<div class="example" id="example-282">
 <div class="examplenum">
-<a href="#example-281">Example 281</a>
+<a href="#example-282">Example 282</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown"><span class="space"> </span><span class="space"> </span>1.<span class="space"> </span><span class="space"> </span>A<span class="space"> </span>paragraph
@@ -9937,9 +10011,9 @@ with<span class="space"> </span>two<span class="space"> </span>lines.&lt;/li&gt;
 </div>
 </div>
 <p>These examples show how laziness can work in nested structures:</p>
-<div class="example" id="example-282">
+<div class="example" id="example-283">
 <div class="examplenum">
-<a href="#example-282">Example 282</a>
+<a href="#example-283">Example 283</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">&gt;<span class="space"> </span>1.<span class="space"> </span>&gt;<span class="space"> </span>Blockquote
@@ -9960,9 +10034,9 @@ continued<span class="space"> </span>here.&lt;/p&gt;
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-283">
+<div class="example" id="example-284">
 <div class="examplenum">
-<a href="#example-283">Example 283</a>
+<a href="#example-284">Example 284</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">&gt;<span class="space"> </span>1.<span class="space"> </span>&gt;<span class="space"> </span>Blockquote
@@ -9992,9 +10066,9 @@ continued<span class="space"> </span>here.&lt;/p&gt;
 of spaces of indentation a paragraph would need to be in order to be included
 in the list item.</p>
 <p>So, in this case we need two spaces indent:</p>
-<div class="example" id="example-284">
+<div class="example" id="example-285">
 <div class="examplenum">
-<a href="#example-284">Example 284</a>
+<a href="#example-285">Example 285</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">-<span class="space"> </span>foo
@@ -10023,9 +10097,9 @@ in the list item.</p>
 </div>
 </div>
 <p>One is not enough:</p>
-<div class="example" id="example-285">
+<div class="example" id="example-286">
 <div class="examplenum">
-<a href="#example-285">Example 285</a>
+<a href="#example-286">Example 286</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">-<span class="space"> </span>foo
@@ -10045,9 +10119,9 @@ in the list item.</p>
 </div>
 </div>
 <p>Here we need four, because the list marker is wider:</p>
-<div class="example" id="example-286">
+<div class="example" id="example-287">
 <div class="examplenum">
-<a href="#example-286">Example 286</a>
+<a href="#example-287">Example 287</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">10)<span class="space"> </span>foo
@@ -10066,9 +10140,9 @@ in the list item.</p>
 </div>
 </div>
 <p>Three is not enough:</p>
-<div class="example" id="example-287">
+<div class="example" id="example-288">
 <div class="examplenum">
-<a href="#example-287">Example 287</a>
+<a href="#example-288">Example 288</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">10)<span class="space"> </span>foo
@@ -10086,9 +10160,9 @@ in the list item.</p>
 </div>
 </div>
 <p>A list may be the first block in a list item:</p>
-<div class="example" id="example-288">
+<div class="example" id="example-289">
 <div class="examplenum">
-<a href="#example-288">Example 288</a>
+<a href="#example-289">Example 289</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">-<span class="space"> </span>-<span class="space"> </span>foo
@@ -10105,9 +10179,9 @@ in the list item.</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-289">
+<div class="example" id="example-290">
 <div class="examplenum">
-<a href="#example-289">Example 289</a>
+<a href="#example-290">Example 290</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">1.<span class="space"> </span>-<span class="space"> </span>2.<span class="space"> </span>foo
@@ -10129,9 +10203,9 @@ in the list item.</p>
 </div>
 </div>
 <p>A list item can contain a heading:</p>
-<div class="example" id="example-290">
+<div class="example" id="example-291">
 <div class="examplenum">
-<a href="#example-290">Example 290</a>
+<a href="#example-291">Example 291</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">-<span class="space"> </span>#<span class="space"> </span>Foo
@@ -10339,9 +10413,9 @@ between them.  Otherwise a list is <a id="tight" href="#tight" class="definition
 (The difference in HTML output is that paragraphs in a loose list are
 wrapped in <code>&lt;p&gt;</code> tags, while paragraphs in a tight list are not.)</p>
 <p>Changing the bullet or ordered list delimiter starts a new list:</p>
-<div class="example" id="example-291">
+<div class="example" id="example-292">
 <div class="examplenum">
-<a href="#example-291">Example 291</a>
+<a href="#example-292">Example 292</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">-<span class="space"> </span>foo
@@ -10360,9 +10434,9 @@ wrapped in <code>&lt;p&gt;</code> tags, while paragraphs in a tight list are not
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-292">
+<div class="example" id="example-293">
 <div class="examplenum">
-<a href="#example-292">Example 292</a>
+<a href="#example-293">Example 293</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">1.<span class="space"> </span>foo
@@ -10384,9 +10458,9 @@ wrapped in <code>&lt;p&gt;</code> tags, while paragraphs in a tight list are not
 <p>In CommonMark, a list can interrupt a paragraph. That is,
 no blank line is needed to separate a paragraph from a following
 list:</p>
-<div class="example" id="example-293">
+<div class="example" id="example-294">
 <div class="examplenum">
-<a href="#example-293">Example 293</a>
+<a href="#example-294">Example 294</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">Foo
@@ -10452,9 +10526,9 @@ even inside other list items.)</p>
 <p>In order to solve the problem of unwanted lists in paragraphs with
 hard-wrapped numerals, we allow only lists starting with <code>1</code> to
 interrupt paragraphs.  Thus,</p>
-<div class="example" id="example-294">
+<div class="example" id="example-295">
 <div class="examplenum">
-<a href="#example-294">Example 294</a>
+<a href="#example-295">Example 295</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">The<span class="space"> </span>number<span class="space"> </span>of<span class="space"> </span>windows<span class="space"> </span>in<span class="space"> </span>my<span class="space"> </span>house<span class="space"> </span>is
@@ -10468,9 +10542,9 @@ interrupt paragraphs.  Thus,</p>
 </div>
 </div>
 <p>We may still get an unintended result in cases like</p>
-<div class="example" id="example-295">
+<div class="example" id="example-296">
 <div class="examplenum">
-<a href="#example-295">Example 295</a>
+<a href="#example-296">Example 296</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">The<span class="space"> </span>number<span class="space"> </span>of<span class="space"> </span>windows<span class="space"> </span>in<span class="space"> </span>my<span class="space"> </span>house<span class="space"> </span>is
@@ -10487,9 +10561,9 @@ interrupt paragraphs.  Thus,</p>
 </div>
 <p>but this rule should prevent most spurious list captures.</p>
 <p>There can be any number of blank lines between items:</p>
-<div class="example" id="example-296">
+<div class="example" id="example-297">
 <div class="examplenum">
-<a href="#example-296">Example 296</a>
+<a href="#example-297">Example 297</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">-<span class="space"> </span>foo
@@ -10515,9 +10589,9 @@ interrupt paragraphs.  Thus,</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-297">
+<div class="example" id="example-298">
 <div class="examplenum">
-<a href="#example-297">Example 297</a>
+<a href="#example-298">Example 298</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">-<span class="space"> </span>foo
@@ -10550,9 +10624,9 @@ interrupt paragraphs.  Thus,</p>
 list from an indented code block that would otherwise be parsed
 as a subparagraph of the final list item, you can insert a blank HTML
 comment:</p>
-<div class="example" id="example-298">
+<div class="example" id="example-299">
 <div class="examplenum">
-<a href="#example-298">Example 298</a>
+<a href="#example-299">Example 299</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">-<span class="space"> </span>foo
@@ -10577,9 +10651,9 @@ comment:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-299">
+<div class="example" id="example-300">
 <div class="examplenum">
-<a href="#example-299">Example 299</a>
+<a href="#example-300">Example 300</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">-<span class="space"> </span><span class="space"> </span><span class="space"> </span>foo
@@ -10613,9 +10687,9 @@ comment:</p>
 list items will be treated as items at the same list level,
 since none is indented enough to belong to the previous list
 item:</p>
-<div class="example" id="example-300">
+<div class="example" id="example-301">
 <div class="examplenum">
-<a href="#example-300">Example 300</a>
+<a href="#example-301">Example 301</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">-<span class="space"> </span>a
@@ -10640,9 +10714,9 @@ item:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-301">
+<div class="example" id="example-302">
 <div class="examplenum">
-<a href="#example-301">Example 301</a>
+<a href="#example-302">Example 302</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">1.<span class="space"> </span>a
@@ -10670,9 +10744,9 @@ item:</p>
 <p>Note, however, that list items may not be preceded by more than
 three spaces of indentation.  Here <code>- e</code> is treated as a paragraph continuation
 line, because it is indented more than three spaces:</p>
-<div class="example" id="example-302">
+<div class="example" id="example-303">
 <div class="examplenum">
-<a href="#example-302">Example 302</a>
+<a href="#example-303">Example 303</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">-<span class="space"> </span>a
@@ -10696,9 +10770,9 @@ line, because it is indented more than three spaces:</p>
 <p>And here, <code>3. c</code> is treated as in indented code block,
 because it is indented four spaces and preceded by a
 blank line.</p>
-<div class="example" id="example-303">
+<div class="example" id="example-304">
 <div class="examplenum">
-<a href="#example-303">Example 303</a>
+<a href="#example-304">Example 304</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">1.<span class="space"> </span>a
@@ -10724,9 +10798,9 @@ blank line.</p>
 </div>
 <p>This is a loose list, because there is a blank line between
 two of the list items:</p>
-<div class="example" id="example-304">
+<div class="example" id="example-305">
 <div class="examplenum">
-<a href="#example-304">Example 304</a>
+<a href="#example-305">Example 305</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">-<span class="space"> </span>a
@@ -10751,9 +10825,9 @@ two of the list items:</p>
 </div>
 </div>
 <p>So is this, with a empty second item:</p>
-<div class="example" id="example-305">
+<div class="example" id="example-306">
 <div class="examplenum">
-<a href="#example-305">Example 305</a>
+<a href="#example-306">Example 306</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">*<span class="space"> </span>a
@@ -10778,9 +10852,9 @@ two of the list items:</p>
 <p>These are loose lists, even though there are no blank lines between the items,
 because one of the items directly contains two block-level elements
 with a blank line between them:</p>
-<div class="example" id="example-306">
+<div class="example" id="example-307">
 <div class="examplenum">
-<a href="#example-306">Example 306</a>
+<a href="#example-307">Example 307</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">-<span class="space"> </span>a
@@ -10806,9 +10880,9 @@ with a blank line between them:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-307">
+<div class="example" id="example-308">
 <div class="examplenum">
-<a href="#example-307">Example 307</a>
+<a href="#example-308">Example 308</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">-<span class="space"> </span>a
@@ -10834,9 +10908,9 @@ with a blank line between them:</p>
 </div>
 </div>
 <p>This is a tight list, because the blank lines are in a code block:</p>
-<div class="example" id="example-308">
+<div class="example" id="example-309">
 <div class="examplenum">
-<a href="#example-308">Example 308</a>
+<a href="#example-309">Example 309</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">-<span class="space"> </span>a
@@ -10865,9 +10939,9 @@ with a blank line between them:</p>
 <p>This is a tight list, because the blank line is between two
 paragraphs of a sublist.  So the sublist is loose while
 the outer list is tight:</p>
-<div class="example" id="example-309">
+<div class="example" id="example-310">
 <div class="examplenum">
-<a href="#example-309">Example 309</a>
+<a href="#example-310">Example 310</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">-<span class="space"> </span>a
@@ -10894,9 +10968,9 @@ the outer list is tight:</p>
 </div>
 <p>This is a tight list, because the blank line is inside the
 block quote:</p>
-<div class="example" id="example-310">
+<div class="example" id="example-311">
 <div class="examplenum">
-<a href="#example-310">Example 310</a>
+<a href="#example-311">Example 311</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">*<span class="space"> </span>a
@@ -10919,9 +10993,9 @@ block quote:</p>
 </div>
 <p>This list is tight, because the consecutive block elements
 are not separated by blank lines:</p>
-<div class="example" id="example-311">
+<div class="example" id="example-312">
 <div class="examplenum">
-<a href="#example-311">Example 311</a>
+<a href="#example-312">Example 312</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">-<span class="space"> </span>a
@@ -10947,9 +11021,9 @@ are not separated by blank lines:</p>
 </div>
 </div>
 <p>A single-paragraph list is tight:</p>
-<div class="example" id="example-312">
+<div class="example" id="example-313">
 <div class="examplenum">
-<a href="#example-312">Example 312</a>
+<a href="#example-313">Example 313</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">-<span class="space"> </span>a
@@ -10962,9 +11036,9 @@ are not separated by blank lines:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-313">
+<div class="example" id="example-314">
 <div class="examplenum">
-<a href="#example-313">Example 313</a>
+<a href="#example-314">Example 314</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">-<span class="space"> </span>a
@@ -10984,9 +11058,9 @@ are not separated by blank lines:</p>
 </div>
 <p>This list is loose, because of the blank line between the
 two block elements in the list item:</p>
-<div class="example" id="example-314">
+<div class="example" id="example-315">
 <div class="examplenum">
-<a href="#example-314">Example 314</a>
+<a href="#example-315">Example 315</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">1.<span class="space"> </span>```
@@ -11008,9 +11082,9 @@ two block elements in the list item:</p>
 </div>
 </div>
 <p>Here the outer list is loose, the inner list tight:</p>
-<div class="example" id="example-315">
+<div class="example" id="example-316">
 <div class="examplenum">
-<a href="#example-315">Example 315</a>
+<a href="#example-316">Example 316</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">*<span class="space"> </span>foo
@@ -11032,9 +11106,9 @@ two block elements in the list item:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-316">
+<div class="example" id="example-317">
 <div class="examplenum">
-<a href="#example-316">Example 316</a>
+<a href="#example-317">Example 317</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">-<span class="space"> </span>a
@@ -11084,9 +11158,9 @@ biggest ones:</p>
 <p>This list gets rendered as 3,4,5 (not 3,2,1), since Markdown does not have a way
 of specifying that a list is descending, and it does not infer it from the order
 by default:</p>
-<div class="example" id="example-317">
+<div class="example" id="example-318">
 <div class="examplenum">
-<a href="#example-317">Example 317</a>
+<a href="#example-318">Example 318</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">before
@@ -11111,9 +11185,9 @@ after
 </div>
 <p>This looks like a list, but it is in fact a paragraph. There are no break tags
 after the foo, bar and baz, just soft breaks:</p>
-<div class="example" id="example-318">
+<div class="example" id="example-319">
 <div class="examplenum">
-<a href="#example-318">Example 318</a>
+<a href="#example-319">Example 319</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">before
@@ -11188,9 +11262,9 @@ limitations, and should support both <code>.</code> and <code>)</code> as list d
 <span class="number">8.5.2</span>Lists with Attributes: Good Style
 </h3>
 <p>This list will be numbered a, b, c, and will have the delimiter of <code>.</code>:</p>
-<div class="example" id="example-319">
+<div class="example" id="example-320">
 <div class="examplenum">
-<a href="#example-319">Example 319</a>
+<a href="#example-320">Example 320</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">before
@@ -11215,9 +11289,9 @@ after
 </div>
 </div>
 <p>This list will be numbered a, b, c, and will have the delimiter of <code>.</code>:</p>
-<div class="example" id="example-320">
+<div class="example" id="example-321">
 <div class="examplenum">
-<a href="#example-320">Example 320</a>
+<a href="#example-321">Example 321</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">before
@@ -11243,9 +11317,9 @@ after
 </div>
 <p>This list will be numbered a, b, c, and will have the delimiter of <code>)</code> in
 output formats that support it (e.g. in PDF but not in HTML):</p>
-<div class="example" id="example-321">
+<div class="example" id="example-322">
 <div class="examplenum">
-<a href="#example-321">Example 321</a>
+<a href="#example-322">Example 322</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">before
@@ -11271,9 +11345,9 @@ after
 </div>
 <p>This list will be numbered a, b, c, and will have the delimiter of <code>)</code> in
 output formats that support it (e.g. in PDF but not in HTML):</p>
-<div class="example" id="example-322">
+<div class="example" id="example-323">
 <div class="examplenum">
-<a href="#example-322">Example 322</a>
+<a href="#example-323">Example 323</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">before
@@ -11298,9 +11372,9 @@ after
 </div>
 </div>
 <p>This list will be numbered A, B, C:</p>
-<div class="example" id="example-323">
+<div class="example" id="example-324">
 <div class="examplenum">
-<a href="#example-323">Example 323</a>
+<a href="#example-324">Example 324</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">before
@@ -11325,9 +11399,9 @@ after
 </div>
 </div>
 <p>This list will be numbered c, d, e:</p>
-<div class="example" id="example-324">
+<div class="example" id="example-325">
 <div class="examplenum">
-<a href="#example-324">Example 324</a>
+<a href="#example-325">Example 325</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">before
@@ -11352,9 +11426,9 @@ after
 </div>
 </div>
 <p>This list will be numbered i, ii, iii:</p>
-<div class="example" id="example-325">
+<div class="example" id="example-326">
 <div class="examplenum">
-<a href="#example-325">Example 325</a>
+<a href="#example-326">Example 326</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">before
@@ -11379,9 +11453,9 @@ after
 </div>
 </div>
 <p>This list will be numbered I, II, III:</p>
-<div class="example" id="example-326">
+<div class="example" id="example-327">
 <div class="examplenum">
-<a href="#example-326">Example 326</a>
+<a href="#example-327">Example 327</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">before
@@ -11406,9 +11480,9 @@ after
 </div>
 </div>
 <p>This list will be numbered iii, iv, v:</p>
-<div class="example" id="example-327">
+<div class="example" id="example-328">
 <div class="examplenum">
-<a href="#example-327">Example 327</a>
+<a href="#example-328">Example 328</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">before
@@ -11433,9 +11507,9 @@ after
 </div>
 </div>
 <p>This list will be numbered 3, 2, 1:</p>
-<div class="example" id="example-328">
+<div class="example" id="example-329">
 <div class="examplenum">
-<a href="#example-328">Example 328</a>
+<a href="#example-329">Example 329</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">before
@@ -11460,9 +11534,9 @@ after
 </div>
 </div>
 <p>This list will be numbered c, b, a:</p>
-<div class="example" id="example-329">
+<div class="example" id="example-330">
 <div class="examplenum">
-<a href="#example-329">Example 329</a>
+<a href="#example-330">Example 330</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">before
@@ -11487,9 +11561,9 @@ after
 </div>
 </div>
 <p>This list will be numbered iii, ii, i:</p>
-<div class="example" id="example-330">
+<div class="example" id="example-331">
 <div class="examplenum">
-<a href="#example-330">Example 330</a>
+<a href="#example-331">Example 331</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">before
@@ -11536,9 +11610,9 @@ right parenthesis (<code>a)</code>, <code>b)</code>, <code>c)</code>, <code>d)</
 <li>The sixth level nested list is numbered using Roman numerals followed by a
 right parenthesis (<code>i)</code>, <code>ii)</code>, <code>iii)</code>, <code>iv)</code>, …)</li>
 </ul>
-<div class="example" id="example-331">
+<div class="example" id="example-332">
 <div class="examplenum">
-<a href="#example-331">Example 331</a>
+<a href="#example-332">Example 332</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">before
@@ -11616,9 +11690,9 @@ instead.</p>
 <p>Everything which has been said about attribute lists on lists applies to nested
 lists as well. This example shows a nested list of the form 1, a, i, * (the
 final nested list is an unordered list, not an ordered list):</p>
-<div class="example" id="example-332">
+<div class="example" id="example-333">
 <div class="examplenum">
-<a href="#example-332">Example 332</a>
+<a href="#example-333">Example 333</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">before
@@ -11694,9 +11768,9 @@ after
 <p>It is acceptable to just use the number of the first label, and rely on list
 behavior.</p>
 <p>This list will be numbered 1, 2, 3:</p>
-<div class="example" id="example-333">
+<div class="example" id="example-334">
 <div class="examplenum">
-<a href="#example-333">Example 333</a>
+<a href="#example-334">Example 334</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">before
@@ -11720,9 +11794,9 @@ after
 </div>
 </div>
 <p>This list will be numbered 3, 4, 5:</p>
-<div class="example" id="example-334">
+<div class="example" id="example-335">
 <div class="examplenum">
-<a href="#example-334">Example 334</a>
+<a href="#example-335">Example 335</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">before
@@ -11746,9 +11820,9 @@ after
 </div>
 </div>
 <p>This list will be numbered c, d, e:</p>
-<div class="example" id="example-335">
+<div class="example" id="example-336">
 <div class="examplenum">
-<a href="#example-335">Example 335</a>
+<a href="#example-336">Example 336</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">before
@@ -11773,9 +11847,9 @@ after
 </div>
 </div>
 <p>This list will be numbered iii, iv, v:</p>
-<div class="example" id="example-336">
+<div class="example" id="example-337">
 <div class="examplenum">
-<a href="#example-336">Example 336</a>
+<a href="#example-337">Example 337</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">before
@@ -11800,9 +11874,9 @@ after
 </div>
 </div>
 <p>This list will be numbered 3, 2, 1:</p>
-<div class="example" id="example-337">
+<div class="example" id="example-338">
 <div class="examplenum">
-<a href="#example-337">Example 337</a>
+<a href="#example-338">Example 338</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">before
@@ -11831,9 +11905,9 @@ after
 </h3>
 <p>This list will be numbered 1, 2, 3. This is just the default behavior made
 explicit:</p>
-<div class="example" id="example-338">
+<div class="example" id="example-339">
 <div class="examplenum">
-<a href="#example-338">Example 338</a>
+<a href="#example-339">Example 339</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">before
@@ -11863,9 +11937,9 @@ after
 <p>This list will be numbered a, b, c, and will have the delimiter of <code>.</code>.
 The reason that this is bad style is that the specified delimiter and the
 inferred delimiter do not match:</p>
-<div class="example" id="example-339">
+<div class="example" id="example-340">
 <div class="examplenum">
-<a href="#example-339">Example 339</a>
+<a href="#example-340">Example 340</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">before
@@ -11893,9 +11967,9 @@ after
 output formats that support it (e.g. in PDF but not in HTML). The reason
 that this is bad style is that the specified delimiter and the inferred
 delimiter do not match:</p>
-<div class="example" id="example-340">
+<div class="example" id="example-341">
 <div class="examplenum">
-<a href="#example-340">Example 340</a>
+<a href="#example-341">Example 341</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">before
@@ -11921,9 +11995,9 @@ after
 </div>
 <p>This list will be numbered 3, 2, 1, not 3, 4, 5. Only the first number matters
 since the reversed attribute is set:</p>
-<div class="example" id="example-341">
+<div class="example" id="example-342">
 <div class="examplenum">
-<a href="#example-341">Example 341</a>
+<a href="#example-342">Example 342</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">before
@@ -11949,9 +12023,9 @@ after
 </div>
 <p>This list will be numbered 1, 0, -1, not 1, 2, 3. Only the first number matters
 since the reversed attribute is set:</p>
-<div class="example" id="example-342">
+<div class="example" id="example-343">
 <div class="examplenum">
-<a href="#example-342">Example 342</a>
+<a href="#example-343">Example 343</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">before
@@ -11976,9 +12050,9 @@ after
 </div>
 </div>
 <p>This list will be numbered c, d, e, regardless of the order of the numbers:</p>
-<div class="example" id="example-343">
+<div class="example" id="example-344">
 <div class="examplenum">
-<a href="#example-343">Example 343</a>
+<a href="#example-344">Example 344</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">before
@@ -12003,9 +12077,9 @@ after
 </div>
 </div>
 <p>This list will be numbered 1, 0, -1:</p>
-<div class="example" id="example-344">
+<div class="example" id="example-345">
 <div class="examplenum">
-<a href="#example-344">Example 344</a>
+<a href="#example-345">Example 345</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">before
@@ -12031,9 +12105,9 @@ after
 </div>
 <p>This list will be numbered i, 0, -1, since the Romans didn’t have the concept of
 zero or negative numbers (and thus neither do Roman numerals):</p>
-<div class="example" id="example-345">
+<div class="example" id="example-346">
 <div class="examplenum">
-<a href="#example-345">Example 345</a>
+<a href="#example-346">Example 346</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">before
@@ -12058,9 +12132,9 @@ after
 </div>
 </div>
 <p>This list will be numbered a, 0, -1, since there are no negative letters either:</p>
-<div class="example" id="example-346">
+<div class="example" id="example-347">
 <div class="examplenum">
-<a href="#example-346">Example 346</a>
+<a href="#example-347">Example 347</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">before
@@ -12091,9 +12165,9 @@ after
 </h2>
 <p>Definition lists are also supported in Markua. To define a definition list, use
 the following syntax:</p>
-<div class="example" id="example-347">
+<div class="example" id="example-348">
 <div class="examplenum">
-<a href="#example-347">Example 347</a>
+<a href="#example-348">Example 348</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">term<span class="space"> </span>1
@@ -12127,9 +12201,9 @@ is desirable for the syntax to remain simple, the <code>&lt;dd&gt;</code> elemen
 contain a <code>&lt;dfn&gt;</code> element.</p>
 <p>There can only be one term per definition, but there can be multiple definitions
 for a term:</p>
-<div class="example" id="example-348">
+<div class="example" id="example-349">
 <div class="examplenum">
-<a href="#example-348">Example 348</a>
+<a href="#example-349">Example 349</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">term<span class="space"> </span>1
@@ -12154,9 +12228,9 @@ term<span class="space"> </span>2
 </div>
 <p>A single term definition list is a definition list, regardless of how many
 definitions for the term exist:</p>
-<div class="example" id="example-349">
+<div class="example" id="example-350">
 <div class="examplenum">
-<a href="#example-349">Example 349</a>
+<a href="#example-350">Example 350</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">term
@@ -12176,9 +12250,9 @@ What you do here is indent the subsequent lines by the same amount of space as
 the initial line.</p>
 <p>(If you do not indent the subsequent lines, then you’re ending the definition
 list and just starting a new paragraph.)</p>
-<div class="example" id="example-350">
+<div class="example" id="example-351">
 <div class="examplenum">
-<a href="#example-350">Example 350</a>
+<a href="#example-351">Example 351</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">before
@@ -12216,9 +12290,9 @@ after
 are handled the same way as single line breaks within paragraphs, and are
 subject to the <code>soft-breaks</code> document setting which defaults to <code>space</code> for
 compatibility with Markdown.</p>
-<div class="example" id="example-351">
+<div class="example" id="example-352">
 <div class="examplenum">
-<a href="#example-351">Example 351</a>
+<a href="#example-352">Example 352</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">before
@@ -12260,9 +12334,9 @@ not just to the list itself. This is useful to do, since in a document with many
 definitions, it’s helpful if the reader scrolls to the right spot or opens to
 the right page.</p>
 <p>To do this, just define a span id on the element itself, and then link to it.</p>
-<div class="example" id="example-352">
+<div class="example" id="example-353">
 <div class="examplenum">
-<a href="#example-352">Example 352</a>
+<a href="#example-353">Example 353</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">foo{#foo}
@@ -12310,9 +12384,9 @@ really long asides.</p>
 <p>For consistency with blockquotes, asides can be siblings of paragraphs or nested
 in them.</p>
 <p>Here’s a short aside:</p>
-<div class="example" id="example-353">
+<div class="example" id="example-354">
 <div class="examplenum">
-<a href="#example-353">Example 353</a>
+<a href="#example-354">Example 354</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">A&gt;<span class="space"> </span>This<span class="space"> </span>is<span class="space"> </span>a<span class="space"> </span>short<span class="space"> </span>aside.
@@ -12326,9 +12400,9 @@ in them.</p>
 </div>
 </div>
 <p>Here’s a longer aside, which also contains a heading:</p>
-<div class="example" id="example-354">
+<div class="example" id="example-355">
 <div class="examplenum">
-<a href="#example-354">Example 354</a>
+<a href="#example-355">Example 355</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">A&gt;<span class="space"> </span>#<span class="space"> </span>A<span class="space"> </span>Longer<span class="space"> </span>Aside
@@ -12348,9 +12422,9 @@ A&gt;<span class="space"> </span>It<span class="space"> </span>can<span class="s
 </div>
 </div>
 <p>Here’s the same longer aside using the <code>{aside}</code> syntax:</p>
-<div class="example" id="example-355">
+<div class="example" id="example-356">
 <div class="examplenum">
-<a href="#example-355">Example 355</a>
+<a href="#example-356">Example 356</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">{aside}
@@ -12385,9 +12459,9 @@ pages of output.</p>
 <li>By wrapping the blurb in <code>{blurb}</code> … <code>{/blurb}</code></li>
 </ol>
 <p>Here’s a short blurb:</p>
-<div class="example" id="example-356">
+<div class="example" id="example-357">
 <div class="examplenum">
-<a href="#example-356">Example 356</a>
+<a href="#example-357">Example 357</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">B&gt;<span class="space"> </span>This<span class="space"> </span>is<span class="space"> </span>a<span class="space"> </span>short<span class="space"> </span>blurb.
@@ -12401,9 +12475,9 @@ pages of output.</p>
 </div>
 </div>
 <p>Here’s a longer blurb, which also contains a heading:</p>
-<div class="example" id="example-357">
+<div class="example" id="example-358">
 <div class="examplenum">
-<a href="#example-357">Example 357</a>
+<a href="#example-358">Example 358</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">B&gt;<span class="space"> </span>#<span class="space"> </span>A<span class="space"> </span>Longer<span class="space"> </span>Blurb
@@ -12423,9 +12497,9 @@ B&gt;<span class="space"> </span>It<span class="space"> </span>can<span class="s
 </div>
 </div>
 <p>Here’s the same longer blurb using the <code>{blurb}</code> syntax:</p>
-<div class="example" id="example-358">
+<div class="example" id="example-359">
 <div class="examplenum">
-<a href="#example-358">Example 358</a>
+<a href="#example-359">Example 359</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">{blurb}
@@ -12466,9 +12540,9 @@ de facto standard:</p>
 Processor can optionally style these blurbs appropriately based on the class,
 for example by adding custom icons for each class of blurb.</p>
 <p>Here’s how this looks with the <code>B&gt; </code> syntax:</p>
-<div class="example" id="example-359">
+<div class="example" id="example-360">
 <div class="examplenum">
-<a href="#example-359">Example 359</a>
+<a href="#example-360">Example 360</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">{class:<span class="space"> </span>warning}
@@ -12483,9 +12557,9 @@ B&gt;<span class="space"> </span>This<span class="space"> </span>is<span class="
 </div>
 </div>
 <p>Here’s how this looks with the <code>{blurb}</code> syntax:</p>
-<div class="example" id="example-360">
+<div class="example" id="example-361">
 <div class="examplenum">
-<a href="#example-360">Example 360</a>
+<a href="#example-361">Example 361</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">{blurb,<span class="space"> </span>class:<span class="space"> </span>warning}
@@ -12533,9 +12607,9 @@ computer programming books:</p>
 : <code>{class: warning}</code></p>
 <p><code>X&gt;</code>
 : <code>{class: exercise}</code></p>
-<div class="example" id="example-361">
+<div class="example" id="example-362">
 <div class="examplenum">
-<a href="#example-361">Example 361</a>
+<a href="#example-362">Example 362</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">D&gt;<span class="space"> </span>This<span class="space"> </span>is<span class="space"> </span>a<span class="space"> </span>discussion<span class="space"> </span>blurb.
@@ -12563,9 +12637,9 @@ This<span class="space"> </span>is<span class="space"> </span>a<span class="spac
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-362">
+<div class="example" id="example-363">
 <div class="examplenum">
-<a href="#example-362">Example 362</a>
+<a href="#example-363">Example 363</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">E&gt;<span class="space"> </span>This<span class="space"> </span>is<span class="space"> </span>an<span class="space"> </span>error<span class="space"> </span>blurb.
@@ -12593,9 +12667,9 @@ This<span class="space"> </span>is<span class="space"> </span>an<span class="spa
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-363">
+<div class="example" id="example-364">
 <div class="examplenum">
-<a href="#example-363">Example 363</a>
+<a href="#example-364">Example 364</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">X&gt;<span class="space"> </span>This<span class="space"> </span>is<span class="space"> </span>an<span class="space"> </span>exercise<span class="space"> </span>blurb.
@@ -12623,9 +12697,9 @@ This<span class="space"> </span>is<span class="space"> </span>an<span class="spa
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-364">
+<div class="example" id="example-365">
 <div class="examplenum">
-<a href="#example-364">Example 364</a>
+<a href="#example-365">Example 365</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">I&gt;<span class="space"> </span>This<span class="space"> </span>is<span class="space"> </span>an<span class="space"> </span>information<span class="space"> </span>blurb.
@@ -12653,9 +12727,9 @@ This<span class="space"> </span>is<span class="space"> </span>an<span class="spa
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-365">
+<div class="example" id="example-366">
 <div class="examplenum">
-<a href="#example-365">Example 365</a>
+<a href="#example-366">Example 366</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">Q&gt;<span class="space"> </span>This<span class="space"> </span>is<span class="space"> </span>a<span class="space"> </span>question<span class="space"> </span>blurb.
@@ -12683,9 +12757,9 @@ This<span class="space"> </span>is<span class="space"> </span>a<span class="spac
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-366">
+<div class="example" id="example-367">
 <div class="examplenum">
-<a href="#example-366">Example 366</a>
+<a href="#example-367">Example 367</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">T&gt;<span class="space"> </span>This<span class="space"> </span>is<span class="space"> </span>a<span class="space"> </span>tip<span class="space"> </span>blurb.
@@ -12713,9 +12787,9 @@ This<span class="space"> </span>is<span class="space"> </span>a<span class="spac
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-367">
+<div class="example" id="example-368">
 <div class="examplenum">
-<a href="#example-367">Example 367</a>
+<a href="#example-368">Example 368</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">W&gt;<span class="space"> </span>This<span class="space"> </span>is<span class="space"> </span>a<span class="space"> </span>warning<span class="space"> </span>blurb.
@@ -12763,9 +12837,9 @@ at the left of the blurb, but other Markua Processors are free to do something
 different.</p>
 <p>Finally, note that specifying a class in metadata overrides what the syntactic
 sugar does, and is also an error:</p>
-<div class="example" id="example-368">
+<div class="example" id="example-369">
 <div class="examplenum">
-<a href="#example-368">Example 368</a>
+<a href="#example-369">Example 369</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">{class:<span class="space"> </span>tip}
@@ -12784,9 +12858,9 @@ W&gt;<span class="space"> </span>This<span class="space"> </span>is<span class="
 </h3>
 <p>You can also use a blurb to center text.</p>
 <p>The following two ways to do this are equivalent:</p>
-<div class="example" id="example-369">
+<div class="example" id="example-370">
 <div class="examplenum">
-<a href="#example-369">Example 369</a>
+<a href="#example-370">Example 370</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">C&gt;<span class="space"> </span>This<span class="space"> </span>is<span class="space"> </span>a<span class="space"> </span>centered<span class="space"> </span>blurb.
@@ -13797,9 +13871,9 @@ well as course outputs. This document setting is also listed in the
 <p>Inlines are parsed sequentially from the beginning of the character
 stream to the end (left to right, in left-to-right languages).
 Thus, for example, in</p>
-<div class="example" id="example-370">
+<div class="example" id="example-371">
 <div class="examplenum">
-<a href="#example-370">Example 370</a>
+<a href="#example-371">Example 371</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">`hi`lo`
@@ -13832,9 +13906,9 @@ or ends with backtick characters, which must be separated by
 whitespace from the opening or closing backtick strings.</li>
 </ul>
 <p>This is a simple code span:</p>
-<div class="example" id="example-371">
+<div class="example" id="example-372">
 <div class="examplenum">
-<a href="#example-371">Example 371</a>
+<a href="#example-372">Example 372</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">`foo`
@@ -13848,9 +13922,9 @@ whitespace from the opening or closing backtick strings.</li>
 <p>Here two backticks are used, because the code contains a backtick.
 This example also illustrates stripping of a single leading and
 trailing space:</p>
-<div class="example" id="example-372">
+<div class="example" id="example-373">
 <div class="examplenum">
-<a href="#example-372">Example 372</a>
+<a href="#example-373">Example 373</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">``<span class="space"> </span>foo<span class="space"> </span>`<span class="space"> </span>bar<span class="space"> </span>``
@@ -13863,9 +13937,9 @@ trailing space:</p>
 </div>
 <p>This example shows the motivation for stripping leading and trailing
 spaces:</p>
-<div class="example" id="example-373">
+<div class="example" id="example-374">
 <div class="examplenum">
-<a href="#example-373">Example 373</a>
+<a href="#example-374">Example 374</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">`<span class="space"> </span>``<span class="space"> </span>`
@@ -13877,9 +13951,9 @@ spaces:</p>
 </div>
 </div>
 <p>Note that only <em>one</em> space is stripped:</p>
-<div class="example" id="example-374">
+<div class="example" id="example-375">
 <div class="examplenum">
-<a href="#example-374">Example 374</a>
+<a href="#example-375">Example 375</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">`<span class="space"> </span><span class="space"> </span>``<span class="space"> </span><span class="space"> </span>`
@@ -13892,9 +13966,9 @@ spaces:</p>
 </div>
 <p>The stripping only happens if the space is on both
 sides of the string:</p>
-<div class="example" id="example-375">
+<div class="example" id="example-376">
 <div class="examplenum">
-<a href="#example-375">Example 375</a>
+<a href="#example-376">Example 376</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">`<span class="space"> </span>a`
@@ -13907,9 +13981,9 @@ sides of the string:</p>
 </div>
 <p>Only <a href="#space">spaces</a>, and not <a href="#unicode-whitespace">unicode whitespace</a> in general, are
 stripped in this way:</p>
-<div class="example" id="example-376">
+<div class="example" id="example-377">
 <div class="examplenum">
-<a href="#example-376">Example 376</a>
+<a href="#example-377">Example 377</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">` b `
@@ -13921,9 +13995,9 @@ stripped in this way:</p>
 </div>
 </div>
 <p>No stripping occurs if the code span contains only spaces:</p>
-<div class="example" id="example-377">
+<div class="example" id="example-378">
 <div class="examplenum">
-<a href="#example-377">Example 377</a>
+<a href="#example-378">Example 378</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">` `
@@ -13937,9 +14011,9 @@ stripped in this way:</p>
 </div>
 </div>
 <p><a href="#line-ending">Line endings</a> are treated like spaces:</p>
-<div class="example" id="example-378">
+<div class="example" id="example-379">
 <div class="examplenum">
-<a href="#example-378">Example 378</a>
+<a href="#example-379">Example 379</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">``
@@ -13954,9 +14028,9 @@ baz
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-379">
+<div class="example" id="example-380">
 <div class="examplenum">
-<a href="#example-379">Example 379</a>
+<a href="#example-380">Example 380</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">``
@@ -13970,9 +14044,9 @@ foo<span class="space"> </span>
 </div>
 </div>
 <p>Interior spaces are not collapsed:</p>
-<div class="example" id="example-380">
+<div class="example" id="example-381">
 <div class="examplenum">
-<a href="#example-380">Example 380</a>
+<a href="#example-381">Example 381</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">`foo<span class="space"> </span><span class="space"> </span><span class="space"> </span>bar<span class="space"> </span>
@@ -13991,9 +14065,9 @@ the following CSS be used:</p>
 </code></pre>
 <p>Note that backslash escapes do not work in code spans. All backslashes
 are treated literally:</p>
-<div class="example" id="example-381">
+<div class="example" id="example-382">
 <div class="examplenum">
-<a href="#example-381">Example 381</a>
+<a href="#example-382">Example 382</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">`foo\`bar`
@@ -14007,9 +14081,9 @@ are treated literally:</p>
 <p>Backslash escapes are never needed, because one can always choose a
 string of <em>n</em> backtick characters as delimiters, where the code does
 not contain any strings of exactly <em>n</em> backtick characters.</p>
-<div class="example" id="example-382">
+<div class="example" id="example-383">
 <div class="examplenum">
-<a href="#example-382">Example 382</a>
+<a href="#example-383">Example 383</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">``foo`bar``
@@ -14020,9 +14094,9 @@ not contain any strings of exactly <em>n</em> backtick characters.</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-383">
+<div class="example" id="example-384">
 <div class="examplenum">
-<a href="#example-383">Example 383</a>
+<a href="#example-384">Example 384</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">`<span class="space"> </span>foo<span class="space"> </span>``<span class="space"> </span>bar<span class="space"> </span>`
@@ -14037,9 +14111,9 @@ not contain any strings of exactly <em>n</em> backtick characters.</p>
 constructs except HTML tags and autolinks.  Thus, for example, this is
 not parsed as emphasized text, since the second <code>*</code> is part of a code
 span:</p>
-<div class="example" id="example-384">
+<div class="example" id="example-385">
 <div class="examplenum">
-<a href="#example-384">Example 384</a>
+<a href="#example-385">Example 385</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">*foo`*`
@@ -14051,9 +14125,9 @@ span:</p>
 </div>
 </div>
 <p>And this is not parsed as a link:</p>
-<div class="example" id="example-385">
+<div class="example" id="example-386">
 <div class="examplenum">
-<a href="#example-385">Example 385</a>
+<a href="#example-386">Example 386</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[not<span class="space"> </span>a<span class="space"> </span>`link](/foo`)
@@ -14066,9 +14140,9 @@ span:</p>
 </div>
 <p>Code spans, HTML tags, and autolinks have the same precedence.
 Thus, this is code:</p>
-<div class="example" id="example-386">
+<div class="example" id="example-387">
 <div class="examplenum">
-<a href="#example-386">Example 386</a>
+<a href="#example-387">Example 387</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">`&lt;a<span class="space"> </span>href=&quot;`&quot;&gt;`
@@ -14080,9 +14154,9 @@ Thus, this is code:</p>
 </div>
 </div>
 <p>But this is an HTML tag:</p>
-<div class="example" id="example-387">
+<div class="example" id="example-388">
 <div class="examplenum">
-<a href="#example-387">Example 387</a>
+<a href="#example-388">Example 388</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">&lt;a<span class="space"> </span>href=&quot;`&quot;&gt;`
@@ -14094,9 +14168,9 @@ Thus, this is code:</p>
 </div>
 </div>
 <p>And this is code:</p>
-<div class="example" id="example-388">
+<div class="example" id="example-389">
 <div class="examplenum">
-<a href="#example-388">Example 388</a>
+<a href="#example-389">Example 389</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">`&lt;https://foo.bar.`baz&gt;`
@@ -14108,9 +14182,9 @@ Thus, this is code:</p>
 </div>
 </div>
 <p>But this is an autolink:</p>
-<div class="example" id="example-389">
+<div class="example" id="example-390">
 <div class="examplenum">
-<a href="#example-389">Example 389</a>
+<a href="#example-390">Example 390</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">&lt;https://foo.bar.`baz&gt;`
@@ -14123,9 +14197,9 @@ Thus, this is code:</p>
 </div>
 <p>When a backtick string is not closed by a matching backtick string,
 we just have literal backticks:</p>
-<div class="example" id="example-390">
+<div class="example" id="example-391">
 <div class="examplenum">
-<a href="#example-390">Example 390</a>
+<a href="#example-391">Example 391</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">```foo``
@@ -14136,9 +14210,9 @@ we just have literal backticks:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-391">
+<div class="example" id="example-392">
 <div class="examplenum">
-<a href="#example-391">Example 391</a>
+<a href="#example-392">Example 392</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">`foo
@@ -14151,9 +14225,9 @@ we just have literal backticks:</p>
 </div>
 <p>The following case also illustrates the need for opening and
 closing backtick strings to be equal in length:</p>
-<div class="example" id="example-392">
+<div class="example" id="example-393">
 <div class="examplenum">
-<a href="#example-392">Example 392</a>
+<a href="#example-393">Example 393</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">`foo``bar``
@@ -14375,9 +14449,9 @@ parsed as <code>*&lt;a href=&quot;bar&quot;&gt;foo*&lt;/a&gt;</code> rather than
 </ol>
 <p>These rules can be illustrated through a series of examples.</p>
 <p>Rule 1:</p>
-<div class="example" id="example-393">
+<div class="example" id="example-394">
 <div class="examplenum">
-<a href="#example-393">Example 393</a>
+<a href="#example-394">Example 394</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">*foo<span class="space"> </span>bar*
@@ -14390,9 +14464,9 @@ parsed as <code>*&lt;a href=&quot;bar&quot;&gt;foo*&lt;/a&gt;</code> rather than
 </div>
 <p>This is not emphasis, because the opening <code>*</code> is followed by
 whitespace, and hence not part of a <a href="#left-flanking-delimiter-run">left-flanking delimiter run</a>:</p>
-<div class="example" id="example-394">
+<div class="example" id="example-395">
 <div class="examplenum">
-<a href="#example-394">Example 394</a>
+<a href="#example-395">Example 395</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">a<span class="space"> </span>*<span class="space"> </span>foo<span class="space"> </span>bar*
@@ -14406,9 +14480,9 @@ whitespace, and hence not part of a <a href="#left-flanking-delimiter-run">left-
 <p>This is not emphasis, because the opening <code>*</code> is preceded
 by an alphanumeric and followed by punctuation, and hence
 not part of a <a href="#left-flanking-delimiter-run">left-flanking delimiter run</a>:</p>
-<div class="example" id="example-395">
+<div class="example" id="example-396">
 <div class="examplenum">
-<a href="#example-395">Example 395</a>
+<a href="#example-396">Example 396</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">a*&quot;foo&quot;*
@@ -14420,9 +14494,9 @@ not part of a <a href="#left-flanking-delimiter-run">left-flanking delimiter run
 </div>
 </div>
 <p>Unicode nonbreaking spaces count as whitespace, too:</p>
-<div class="example" id="example-396">
+<div class="example" id="example-397">
 <div class="examplenum">
-<a href="#example-396">Example 396</a>
+<a href="#example-397">Example 397</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">* a *
@@ -14434,9 +14508,9 @@ not part of a <a href="#left-flanking-delimiter-run">left-flanking delimiter run
 </div>
 </div>
 <p>Unicode symbols count as punctuation, too:</p>
-<div class="example" id="example-397">
+<div class="example" id="example-398">
 <div class="examplenum">
-<a href="#example-397">Example 397</a>
+<a href="#example-398">Example 398</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">*$*alpha.
@@ -14454,9 +14528,9 @@ not part of a <a href="#left-flanking-delimiter-run">left-flanking delimiter run
 </div>
 </div>
 <p>Intraword emphasis with <code>*</code> is permitted:</p>
-<div class="example" id="example-398">
+<div class="example" id="example-399">
 <div class="examplenum">
-<a href="#example-398">Example 398</a>
+<a href="#example-399">Example 399</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">foo*bar*
@@ -14467,9 +14541,9 @@ not part of a <a href="#left-flanking-delimiter-run">left-flanking delimiter run
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-399">
+<div class="example" id="example-400">
 <div class="examplenum">
-<a href="#example-399">Example 399</a>
+<a href="#example-400">Example 400</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">5*6*78
@@ -14481,9 +14555,9 @@ not part of a <a href="#left-flanking-delimiter-run">left-flanking delimiter run
 </div>
 </div>
 <p>Rule 2:</p>
-<div class="example" id="example-400">
+<div class="example" id="example-401">
 <div class="examplenum">
-<a href="#example-400">Example 400</a>
+<a href="#example-401">Example 401</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">_foo<span class="space"> </span>bar_
@@ -14496,9 +14570,9 @@ not part of a <a href="#left-flanking-delimiter-run">left-flanking delimiter run
 </div>
 <p>This is not emphasis, because the opening <code>_</code> is followed by
 whitespace:</p>
-<div class="example" id="example-401">
+<div class="example" id="example-402">
 <div class="examplenum">
-<a href="#example-401">Example 401</a>
+<a href="#example-402">Example 402</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">_<span class="space"> </span>foo<span class="space"> </span>bar_
@@ -14511,9 +14585,9 @@ whitespace:</p>
 </div>
 <p>This is not emphasis, because the opening <code>_</code> is preceded
 by an alphanumeric and followed by punctuation:</p>
-<div class="example" id="example-402">
+<div class="example" id="example-403">
 <div class="examplenum">
-<a href="#example-402">Example 402</a>
+<a href="#example-403">Example 403</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">a_&quot;foo&quot;_
@@ -14525,9 +14599,9 @@ by an alphanumeric and followed by punctuation:</p>
 </div>
 </div>
 <p>Emphasis with <code>_</code> is not allowed inside words:</p>
-<div class="example" id="example-403">
+<div class="example" id="example-404">
 <div class="examplenum">
-<a href="#example-403">Example 403</a>
+<a href="#example-404">Example 404</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">foo_bar_
@@ -14538,9 +14612,9 @@ by an alphanumeric and followed by punctuation:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-404">
+<div class="example" id="example-405">
 <div class="examplenum">
-<a href="#example-404">Example 404</a>
+<a href="#example-405">Example 405</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">5_6_78
@@ -14551,9 +14625,9 @@ by an alphanumeric and followed by punctuation:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-405">
+<div class="example" id="example-406">
 <div class="examplenum">
-<a href="#example-405">Example 405</a>
+<a href="#example-406">Example 406</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">пристаням_стремятся_
@@ -14566,9 +14640,9 @@ by an alphanumeric and followed by punctuation:</p>
 </div>
 <p>Here <code>_</code> does not generate emphasis, because the first delimiter run
 is right-flanking and the second left-flanking:</p>
-<div class="example" id="example-406">
+<div class="example" id="example-407">
 <div class="examplenum">
-<a href="#example-406">Example 406</a>
+<a href="#example-407">Example 407</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">aa_&quot;bb&quot;_cc
@@ -14582,9 +14656,9 @@ is right-flanking and the second left-flanking:</p>
 <p>This is emphasis, even though the opening delimiter is
 both left- and right-flanking, because it is preceded by
 punctuation:</p>
-<div class="example" id="example-407">
+<div class="example" id="example-408">
 <div class="examplenum">
-<a href="#example-407">Example 407</a>
+<a href="#example-408">Example 408</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">foo-_(bar)_
@@ -14598,9 +14672,9 @@ punctuation:</p>
 <p>Rule 3:</p>
 <p>This is not emphasis, because the closing delimiter does
 not match the opening delimiter:</p>
-<div class="example" id="example-408">
+<div class="example" id="example-409">
 <div class="examplenum">
-<a href="#example-408">Example 408</a>
+<a href="#example-409">Example 409</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">_foo*
@@ -14613,9 +14687,9 @@ not match the opening delimiter:</p>
 </div>
 <p>This is not emphasis, because the closing <code>*</code> is preceded by
 whitespace:</p>
-<div class="example" id="example-409">
+<div class="example" id="example-410">
 <div class="examplenum">
-<a href="#example-409">Example 409</a>
+<a href="#example-410">Example 410</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">*foo<span class="space"> </span>bar<span class="space"> </span>*
@@ -14627,9 +14701,9 @@ whitespace:</p>
 </div>
 </div>
 <p>A line ending also counts as whitespace:</p>
-<div class="example" id="example-410">
+<div class="example" id="example-411">
 <div class="examplenum">
-<a href="#example-410">Example 410</a>
+<a href="#example-411">Example 411</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">*foo<span class="space"> </span>bar
@@ -14645,9 +14719,9 @@ whitespace:</p>
 <p>This is not emphasis, because the second <code>*</code> is
 preceded by punctuation and followed by an alphanumeric
 (hence it is not part of a <a href="#right-flanking-delimiter-run">right-flanking delimiter run</a>:</p>
-<div class="example" id="example-411">
+<div class="example" id="example-412">
 <div class="examplenum">
-<a href="#example-411">Example 411</a>
+<a href="#example-412">Example 412</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">*(*foo)
@@ -14660,9 +14734,9 @@ preceded by punctuation and followed by an alphanumeric
 </div>
 <p>The point of this restriction is more easily appreciated
 with this example:</p>
-<div class="example" id="example-412">
+<div class="example" id="example-413">
 <div class="examplenum">
-<a href="#example-412">Example 412</a>
+<a href="#example-413">Example 413</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">*(*foo*)*
@@ -14674,9 +14748,9 @@ with this example:</p>
 </div>
 </div>
 <p>Intraword emphasis with <code>*</code> is allowed:</p>
-<div class="example" id="example-413">
+<div class="example" id="example-414">
 <div class="examplenum">
-<a href="#example-413">Example 413</a>
+<a href="#example-414">Example 414</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">*foo*bar
@@ -14690,9 +14764,9 @@ with this example:</p>
 <p>Rule 4:</p>
 <p>This is not emphasis, because the closing <code>_</code> is preceded by
 whitespace:</p>
-<div class="example" id="example-414">
+<div class="example" id="example-415">
 <div class="examplenum">
-<a href="#example-414">Example 414</a>
+<a href="#example-415">Example 415</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">_foo<span class="space"> </span>bar<span class="space"> </span>_
@@ -14705,9 +14779,9 @@ whitespace:</p>
 </div>
 <p>This is not emphasis, because the second <code>_</code> is
 preceded by punctuation and followed by an alphanumeric:</p>
-<div class="example" id="example-415">
+<div class="example" id="example-416">
 <div class="examplenum">
-<a href="#example-415">Example 415</a>
+<a href="#example-416">Example 416</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">_(_foo)
@@ -14719,9 +14793,9 @@ preceded by punctuation and followed by an alphanumeric:</p>
 </div>
 </div>
 <p>This is emphasis within emphasis:</p>
-<div class="example" id="example-416">
+<div class="example" id="example-417">
 <div class="examplenum">
-<a href="#example-416">Example 416</a>
+<a href="#example-417">Example 417</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">_(_foo_)_
@@ -14733,9 +14807,9 @@ preceded by punctuation and followed by an alphanumeric:</p>
 </div>
 </div>
 <p>Intraword emphasis is disallowed for <code>_</code>:</p>
-<div class="example" id="example-417">
+<div class="example" id="example-418">
 <div class="examplenum">
-<a href="#example-417">Example 417</a>
+<a href="#example-418">Example 418</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">_foo_bar
@@ -14746,9 +14820,9 @@ preceded by punctuation and followed by an alphanumeric:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-418">
+<div class="example" id="example-419">
 <div class="examplenum">
-<a href="#example-418">Example 418</a>
+<a href="#example-419">Example 419</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">_пристаням_стремятся
@@ -14759,9 +14833,9 @@ preceded by punctuation and followed by an alphanumeric:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-419">
+<div class="example" id="example-420">
 <div class="examplenum">
-<a href="#example-419">Example 419</a>
+<a href="#example-420">Example 420</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">_foo_bar_baz_
@@ -14775,9 +14849,9 @@ preceded by punctuation and followed by an alphanumeric:</p>
 <p>This is emphasis, even though the closing delimiter is
 both left- and right-flanking, because it is followed by
 punctuation:</p>
-<div class="example" id="example-420">
+<div class="example" id="example-421">
 <div class="examplenum">
-<a href="#example-420">Example 420</a>
+<a href="#example-421">Example 421</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">_(bar)_.
@@ -14789,9 +14863,9 @@ punctuation:</p>
 </div>
 </div>
 <p>Rule 5:</p>
-<div class="example" id="example-421">
+<div class="example" id="example-422">
 <div class="examplenum">
-<a href="#example-421">Example 421</a>
+<a href="#example-422">Example 422</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">**foo<span class="space"> </span>bar**
@@ -14804,9 +14878,9 @@ punctuation:</p>
 </div>
 <p>This is not strong emphasis, because the opening delimiter is
 followed by whitespace:</p>
-<div class="example" id="example-422">
+<div class="example" id="example-423">
 <div class="examplenum">
-<a href="#example-422">Example 422</a>
+<a href="#example-423">Example 423</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">**<span class="space"> </span>foo<span class="space"> </span>bar**
@@ -14820,9 +14894,9 @@ followed by whitespace:</p>
 <p>This is not strong emphasis, because the opening <code>**</code> is preceded
 by an alphanumeric and followed by punctuation, and hence
 not part of a <a href="#left-flanking-delimiter-run">left-flanking delimiter run</a>:</p>
-<div class="example" id="example-423">
+<div class="example" id="example-424">
 <div class="examplenum">
-<a href="#example-423">Example 423</a>
+<a href="#example-424">Example 424</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">a**&quot;foo&quot;**
@@ -14834,9 +14908,9 @@ not part of a <a href="#left-flanking-delimiter-run">left-flanking delimiter run
 </div>
 </div>
 <p>Intraword strong emphasis with <code>**</code> is permitted:</p>
-<div class="example" id="example-424">
+<div class="example" id="example-425">
 <div class="examplenum">
-<a href="#example-424">Example 424</a>
+<a href="#example-425">Example 425</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">foo**bar**
@@ -14848,9 +14922,9 @@ not part of a <a href="#left-flanking-delimiter-run">left-flanking delimiter run
 </div>
 </div>
 <p>Rule 6:</p>
-<div class="example" id="example-425">
+<div class="example" id="example-426">
 <div class="examplenum">
-<a href="#example-425">Example 425</a>
+<a href="#example-426">Example 426</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">__foo<span class="space"> </span>bar__
@@ -14863,9 +14937,9 @@ not part of a <a href="#left-flanking-delimiter-run">left-flanking delimiter run
 </div>
 <p>This is not strong emphasis, because the opening delimiter is
 followed by whitespace:</p>
-<div class="example" id="example-426">
+<div class="example" id="example-427">
 <div class="examplenum">
-<a href="#example-426">Example 426</a>
+<a href="#example-427">Example 427</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">__<span class="space"> </span>foo<span class="space"> </span>bar__
@@ -14877,9 +14951,9 @@ followed by whitespace:</p>
 </div>
 </div>
 <p>A line ending counts as whitespace:</p>
-<div class="example" id="example-427">
+<div class="example" id="example-428">
 <div class="examplenum">
-<a href="#example-427">Example 427</a>
+<a href="#example-428">Example 428</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">__
@@ -14894,9 +14968,9 @@ foo<span class="space"> </span>bar__&lt;/p&gt;
 </div>
 <p>This is not strong emphasis, because the opening <code>__</code> is preceded
 by an alphanumeric and followed by punctuation:</p>
-<div class="example" id="example-428">
+<div class="example" id="example-429">
 <div class="examplenum">
-<a href="#example-428">Example 428</a>
+<a href="#example-429">Example 429</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">a__&quot;foo&quot;__
@@ -14908,9 +14982,9 @@ by an alphanumeric and followed by punctuation:</p>
 </div>
 </div>
 <p>Intraword strong emphasis is forbidden with <code>__</code>:</p>
-<div class="example" id="example-429">
+<div class="example" id="example-430">
 <div class="examplenum">
-<a href="#example-429">Example 429</a>
+<a href="#example-430">Example 430</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">foo__bar__
@@ -14921,9 +14995,9 @@ by an alphanumeric and followed by punctuation:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-430">
+<div class="example" id="example-431">
 <div class="examplenum">
-<a href="#example-430">Example 430</a>
+<a href="#example-431">Example 431</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">5__6__78
@@ -14934,9 +15008,9 @@ by an alphanumeric and followed by punctuation:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-431">
+<div class="example" id="example-432">
 <div class="examplenum">
-<a href="#example-431">Example 431</a>
+<a href="#example-432">Example 432</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">пристаням__стремятся__
@@ -14947,9 +15021,9 @@ by an alphanumeric and followed by punctuation:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-432">
+<div class="example" id="example-433">
 <div class="examplenum">
-<a href="#example-432">Example 432</a>
+<a href="#example-433">Example 433</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">__foo,<span class="space"> </span>__bar__,<span class="space"> </span>baz__
@@ -14963,9 +15037,9 @@ by an alphanumeric and followed by punctuation:</p>
 <p>This is strong emphasis, even though the opening delimiter is
 both left- and right-flanking, because it is preceded by
 punctuation:</p>
-<div class="example" id="example-433">
+<div class="example" id="example-434">
 <div class="examplenum">
-<a href="#example-433">Example 433</a>
+<a href="#example-434">Example 434</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">foo-__(bar)__
@@ -14979,9 +15053,9 @@ punctuation:</p>
 <p>Rule 7:</p>
 <p>This is not strong emphasis, because the closing delimiter is preceded
 by whitespace:</p>
-<div class="example" id="example-434">
+<div class="example" id="example-435">
 <div class="examplenum">
-<a href="#example-434">Example 434</a>
+<a href="#example-435">Example 435</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">**foo<span class="space"> </span>bar<span class="space"> </span>**
@@ -14996,9 +15070,9 @@ by whitespace:</p>
 Rule 11.)</p>
 <p>This is not strong emphasis, because the second <code>**</code> is
 preceded by punctuation and followed by an alphanumeric:</p>
-<div class="example" id="example-435">
+<div class="example" id="example-436">
 <div class="examplenum">
-<a href="#example-435">Example 435</a>
+<a href="#example-436">Example 436</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">**(**foo)
@@ -15011,9 +15085,9 @@ preceded by punctuation and followed by an alphanumeric:</p>
 </div>
 <p>The point of this restriction is more easily appreciated
 with these examples:</p>
-<div class="example" id="example-436">
+<div class="example" id="example-437">
 <div class="examplenum">
-<a href="#example-436">Example 436</a>
+<a href="#example-437">Example 437</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">*(**foo**)*
@@ -15024,9 +15098,9 @@ with these examples:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-437">
+<div class="example" id="example-438">
 <div class="examplenum">
-<a href="#example-437">Example 437</a>
+<a href="#example-438">Example 438</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">**Gomphocarpus<span class="space"> </span>(*Gomphocarpus<span class="space"> </span>physocarpus*,<span class="space"> </span>syn.
@@ -15039,9 +15113,9 @@ with these examples:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-438">
+<div class="example" id="example-439">
 <div class="examplenum">
-<a href="#example-438">Example 438</a>
+<a href="#example-439">Example 439</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">**foo<span class="space"> </span>&quot;*bar*&quot;<span class="space"> </span>foo**
@@ -15053,9 +15127,9 @@ with these examples:</p>
 </div>
 </div>
 <p>Intraword emphasis:</p>
-<div class="example" id="example-439">
+<div class="example" id="example-440">
 <div class="examplenum">
-<a href="#example-439">Example 439</a>
+<a href="#example-440">Example 440</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">**foo**bar
@@ -15069,9 +15143,9 @@ with these examples:</p>
 <p>Rule 8:</p>
 <p>This is not strong emphasis, because the closing delimiter is
 preceded by whitespace:</p>
-<div class="example" id="example-440">
+<div class="example" id="example-441">
 <div class="examplenum">
-<a href="#example-440">Example 440</a>
+<a href="#example-441">Example 441</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">__foo<span class="space"> </span>bar<span class="space"> </span>__
@@ -15084,9 +15158,9 @@ preceded by whitespace:</p>
 </div>
 <p>This is not strong emphasis, because the second <code>__</code> is
 preceded by punctuation and followed by an alphanumeric:</p>
-<div class="example" id="example-441">
+<div class="example" id="example-442">
 <div class="examplenum">
-<a href="#example-441">Example 441</a>
+<a href="#example-442">Example 442</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">__(__foo)
@@ -15099,9 +15173,9 @@ preceded by punctuation and followed by an alphanumeric:</p>
 </div>
 <p>The point of this restriction is more easily appreciated
 with this example:</p>
-<div class="example" id="example-442">
+<div class="example" id="example-443">
 <div class="examplenum">
-<a href="#example-442">Example 442</a>
+<a href="#example-443">Example 443</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">_(__foo__)_
@@ -15113,9 +15187,9 @@ with this example:</p>
 </div>
 </div>
 <p>Intraword strong emphasis is forbidden with <code>__</code>:</p>
-<div class="example" id="example-443">
+<div class="example" id="example-444">
 <div class="examplenum">
-<a href="#example-443">Example 443</a>
+<a href="#example-444">Example 444</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">__foo__bar
@@ -15126,9 +15200,9 @@ with this example:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-444">
+<div class="example" id="example-445">
 <div class="examplenum">
-<a href="#example-444">Example 444</a>
+<a href="#example-445">Example 445</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">__пристаням__стремятся
@@ -15139,9 +15213,9 @@ with this example:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-445">
+<div class="example" id="example-446">
 <div class="examplenum">
-<a href="#example-445">Example 445</a>
+<a href="#example-446">Example 446</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">__foo__bar__baz__
@@ -15155,9 +15229,9 @@ with this example:</p>
 <p>This is strong emphasis, even though the closing delimiter is
 both left- and right-flanking, because it is followed by
 punctuation:</p>
-<div class="example" id="example-446">
+<div class="example" id="example-447">
 <div class="examplenum">
-<a href="#example-446">Example 446</a>
+<a href="#example-447">Example 447</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">__(bar)__.
@@ -15171,9 +15245,9 @@ punctuation:</p>
 <p>Rule 9:</p>
 <p>Any nonempty sequence of inline elements can be the contents of an
 emphasized span.</p>
-<div class="example" id="example-447">
+<div class="example" id="example-448">
 <div class="examplenum">
-<a href="#example-447">Example 447</a>
+<a href="#example-448">Example 448</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">*foo<span class="space"> </span>[bar](/url)*
@@ -15184,9 +15258,9 @@ emphasized span.</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-448">
+<div class="example" id="example-449">
 <div class="examplenum">
-<a href="#example-448">Example 448</a>
+<a href="#example-449">Example 449</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">*foo
@@ -15201,9 +15275,9 @@ bar&lt;/em&gt;&lt;/p&gt;
 </div>
 <p>In particular, emphasis and strong emphasis can be nested
 inside emphasis:</p>
-<div class="example" id="example-449">
+<div class="example" id="example-450">
 <div class="examplenum">
-<a href="#example-449">Example 449</a>
+<a href="#example-450">Example 450</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">_foo<span class="space"> </span>__bar__<span class="space"> </span>baz_
@@ -15214,9 +15288,9 @@ inside emphasis:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-450">
+<div class="example" id="example-451">
 <div class="examplenum">
-<a href="#example-450">Example 450</a>
+<a href="#example-451">Example 451</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">_foo<span class="space"> </span>_bar_<span class="space"> </span>baz_
@@ -15227,9 +15301,9 @@ inside emphasis:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-451">
+<div class="example" id="example-452">
 <div class="examplenum">
-<a href="#example-451">Example 451</a>
+<a href="#example-452">Example 452</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">__foo_<span class="space"> </span>bar_
@@ -15240,9 +15314,9 @@ inside emphasis:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-452">
+<div class="example" id="example-453">
 <div class="examplenum">
-<a href="#example-452">Example 452</a>
+<a href="#example-453">Example 453</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">*foo<span class="space"> </span>*bar**
@@ -15253,9 +15327,9 @@ inside emphasis:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-453">
+<div class="example" id="example-454">
 <div class="examplenum">
-<a href="#example-453">Example 453</a>
+<a href="#example-454">Example 454</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">*foo<span class="space"> </span>**bar**<span class="space"> </span>baz*
@@ -15266,9 +15340,9 @@ inside emphasis:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-454">
+<div class="example" id="example-455">
 <div class="examplenum">
-<a href="#example-454">Example 454</a>
+<a href="#example-455">Example 455</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">*foo**bar**baz*
@@ -15290,9 +15364,9 @@ closing delimiters is a multiple of 3 unless
 both lengths are multiples of 3.</p>
 <p>For the same reason, we don’t get two consecutive
 emphasis sections in this example:</p>
-<div class="example" id="example-455">
+<div class="example" id="example-456">
 <div class="examplenum">
-<a href="#example-455">Example 455</a>
+<a href="#example-456">Example 456</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">*foo**bar*
@@ -15307,9 +15381,9 @@ emphasis sections in this example:</p>
 cases are all strong emphasis nested inside
 emphasis, even when the interior whitespace is
 omitted:</p>
-<div class="example" id="example-456">
+<div class="example" id="example-457">
 <div class="examplenum">
-<a href="#example-456">Example 456</a>
+<a href="#example-457">Example 457</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">***foo**<span class="space"> </span>bar*
@@ -15320,9 +15394,9 @@ omitted:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-457">
+<div class="example" id="example-458">
 <div class="examplenum">
-<a href="#example-457">Example 457</a>
+<a href="#example-458">Example 458</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">*foo<span class="space"> </span>**bar***
@@ -15333,9 +15407,9 @@ omitted:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-458">
+<div class="example" id="example-459">
 <div class="examplenum">
-<a href="#example-458">Example 458</a>
+<a href="#example-459">Example 459</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">*foo**bar***
@@ -15349,9 +15423,9 @@ omitted:</p>
 <p>When the lengths of the interior closing and opening
 delimiter runs are <em>both</em> multiples of 3, though,
 they can match to create emphasis:</p>
-<div class="example" id="example-459">
+<div class="example" id="example-460">
 <div class="examplenum">
-<a href="#example-459">Example 459</a>
+<a href="#example-460">Example 460</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">foo***bar***baz
@@ -15362,9 +15436,9 @@ they can match to create emphasis:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-460">
+<div class="example" id="example-461">
 <div class="examplenum">
-<a href="#example-460">Example 460</a>
+<a href="#example-461">Example 461</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">foo******bar*********baz
@@ -15376,9 +15450,9 @@ they can match to create emphasis:</p>
 </div>
 </div>
 <p>Indefinite levels of nesting are possible:</p>
-<div class="example" id="example-461">
+<div class="example" id="example-462">
 <div class="examplenum">
-<a href="#example-461">Example 461</a>
+<a href="#example-462">Example 462</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">*foo<span class="space"> </span>**bar<span class="space"> </span>*baz*<span class="space"> </span>bim**<span class="space"> </span>bop*
@@ -15389,9 +15463,9 @@ they can match to create emphasis:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-462">
+<div class="example" id="example-463">
 <div class="examplenum">
-<a href="#example-462">Example 462</a>
+<a href="#example-463">Example 463</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">*foo<span class="space"> </span>[*bar*](/url)*
@@ -15403,9 +15477,9 @@ they can match to create emphasis:</p>
 </div>
 </div>
 <p>There can be no empty emphasis or strong emphasis:</p>
-<div class="example" id="example-463">
+<div class="example" id="example-464">
 <div class="examplenum">
-<a href="#example-463">Example 463</a>
+<a href="#example-464">Example 464</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">**<span class="space"> </span>is<span class="space"> </span>not<span class="space"> </span>an<span class="space"> </span>empty<span class="space"> </span>emphasis
@@ -15416,9 +15490,9 @@ they can match to create emphasis:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-464">
+<div class="example" id="example-465">
 <div class="examplenum">
-<a href="#example-464">Example 464</a>
+<a href="#example-465">Example 465</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">****<span class="space"> </span>is<span class="space"> </span>not<span class="space"> </span>an<span class="space"> </span>empty<span class="space"> </span>strong<span class="space"> </span>emphasis
@@ -15432,9 +15506,9 @@ they can match to create emphasis:</p>
 <p>Rule 10:</p>
 <p>Any nonempty sequence of inline elements can be the contents of an
 strongly emphasized span.</p>
-<div class="example" id="example-465">
+<div class="example" id="example-466">
 <div class="examplenum">
-<a href="#example-465">Example 465</a>
+<a href="#example-466">Example 466</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">**foo<span class="space"> </span>[bar](/url)**
@@ -15445,9 +15519,9 @@ strongly emphasized span.</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-466">
+<div class="example" id="example-467">
 <div class="examplenum">
-<a href="#example-466">Example 466</a>
+<a href="#example-467">Example 467</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">**foo
@@ -15462,9 +15536,9 @@ bar&lt;/strong&gt;&lt;/p&gt;
 </div>
 <p>In particular, emphasis and strong emphasis can be nested
 inside strong emphasis:</p>
-<div class="example" id="example-467">
+<div class="example" id="example-468">
 <div class="examplenum">
-<a href="#example-467">Example 467</a>
+<a href="#example-468">Example 468</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">__foo<span class="space"> </span>_bar_<span class="space"> </span>baz__
@@ -15475,9 +15549,9 @@ inside strong emphasis:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-468">
+<div class="example" id="example-469">
 <div class="examplenum">
-<a href="#example-468">Example 468</a>
+<a href="#example-469">Example 469</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">__foo<span class="space"> </span>__bar__<span class="space"> </span>baz__
@@ -15488,9 +15562,9 @@ inside strong emphasis:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-469">
+<div class="example" id="example-470">
 <div class="examplenum">
-<a href="#example-469">Example 469</a>
+<a href="#example-470">Example 470</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">____foo__<span class="space"> </span>bar__
@@ -15501,9 +15575,9 @@ inside strong emphasis:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-470">
+<div class="example" id="example-471">
 <div class="examplenum">
-<a href="#example-470">Example 470</a>
+<a href="#example-471">Example 471</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">**foo<span class="space"> </span>**bar****
@@ -15514,9 +15588,9 @@ inside strong emphasis:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-471">
+<div class="example" id="example-472">
 <div class="examplenum">
-<a href="#example-471">Example 471</a>
+<a href="#example-472">Example 472</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">**foo<span class="space"> </span>*bar*<span class="space"> </span>baz**
@@ -15527,9 +15601,9 @@ inside strong emphasis:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-472">
+<div class="example" id="example-473">
 <div class="examplenum">
-<a href="#example-472">Example 472</a>
+<a href="#example-473">Example 473</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">**foo*bar*baz**
@@ -15540,9 +15614,9 @@ inside strong emphasis:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-473">
+<div class="example" id="example-474">
 <div class="examplenum">
-<a href="#example-473">Example 473</a>
+<a href="#example-474">Example 474</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">***foo*<span class="space"> </span>bar**
@@ -15553,9 +15627,9 @@ inside strong emphasis:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-474">
+<div class="example" id="example-475">
 <div class="examplenum">
-<a href="#example-474">Example 474</a>
+<a href="#example-475">Example 475</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">**foo<span class="space"> </span>*bar***
@@ -15567,9 +15641,9 @@ inside strong emphasis:</p>
 </div>
 </div>
 <p>Indefinite levels of nesting are possible:</p>
-<div class="example" id="example-475">
+<div class="example" id="example-476">
 <div class="examplenum">
-<a href="#example-475">Example 475</a>
+<a href="#example-476">Example 476</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">**foo<span class="space"> </span>*bar<span class="space"> </span>**baz**
@@ -15582,9 +15656,9 @@ bim&lt;/em&gt;<span class="space"> </span>bop&lt;/strong&gt;&lt;/p&gt;
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-476">
+<div class="example" id="example-477">
 <div class="examplenum">
-<a href="#example-476">Example 476</a>
+<a href="#example-477">Example 477</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">**foo<span class="space"> </span>[*bar*](/url)**
@@ -15596,9 +15670,9 @@ bim&lt;/em&gt;<span class="space"> </span>bop&lt;/strong&gt;&lt;/p&gt;
 </div>
 </div>
 <p>There can be no empty emphasis or strong emphasis:</p>
-<div class="example" id="example-477">
+<div class="example" id="example-478">
 <div class="examplenum">
-<a href="#example-477">Example 477</a>
+<a href="#example-478">Example 478</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">__<span class="space"> </span>is<span class="space"> </span>not<span class="space"> </span>an<span class="space"> </span>empty<span class="space"> </span>emphasis
@@ -15609,23 +15683,26 @@ bim&lt;/em&gt;<span class="space"> </span>bop&lt;/strong&gt;&lt;/p&gt;
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-478">
+<div class="example" id="example-479">
 <div class="examplenum">
-<a href="#example-478">Example 478</a>
+<a href="#example-479">Example 479</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">____<span class="space"> </span>is<span class="space"> </span>not<span class="space"> </span>an<span class="space"> </span>empty<span class="space"> </span>strong<span class="space"> </span>emphasis
 </code></pre>
 </div>
 <div class="column">
-<pre><code class="language-html">&lt;p&gt;____<span class="space"> </span>is<span class="space"> </span>not<span class="space"> </span>an<span class="space"> </span>empty<span class="space"> </span>strong<span class="space"> </span>emphasis&lt;/p&gt;
+<pre><code class="language-html">&lt;p&gt;&lt;span<span class="space"> </span>class=&quot;blank&quot;&gt;____&lt;/span&gt;<span class="space"> </span>is<span class="space"> </span>not<span class="space"> </span>an<span class="space"> </span>empty<span class="space"> </span>strong<span class="space"> </span>emphasis&lt;/p&gt;
 </code></pre>
 </div>
 </div>
+<p>(In CommonMark, the <code>____</code> in the previous example would render as four
+literal underscores. In Markua, an isolated run of four or more underscores
+is a <a href="#blanks-m-">blank</a>. Either way, it is not emphasis.)</p>
 <p>Rule 11:</p>
-<div class="example" id="example-479">
+<div class="example" id="example-480">
 <div class="examplenum">
-<a href="#example-479">Example 479</a>
+<a href="#example-480">Example 480</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">foo<span class="space"> </span>***
@@ -15636,9 +15713,9 @@ bim&lt;/em&gt;<span class="space"> </span>bop&lt;/strong&gt;&lt;/p&gt;
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-480">
+<div class="example" id="example-481">
 <div class="examplenum">
-<a href="#example-480">Example 480</a>
+<a href="#example-481">Example 481</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">foo<span class="space"> </span>*\**
@@ -15649,9 +15726,9 @@ bim&lt;/em&gt;<span class="space"> </span>bop&lt;/strong&gt;&lt;/p&gt;
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-481">
+<div class="example" id="example-482">
 <div class="examplenum">
-<a href="#example-481">Example 481</a>
+<a href="#example-482">Example 482</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">foo<span class="space"> </span>*_*
@@ -15662,9 +15739,9 @@ bim&lt;/em&gt;<span class="space"> </span>bop&lt;/strong&gt;&lt;/p&gt;
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-482">
+<div class="example" id="example-483">
 <div class="examplenum">
-<a href="#example-482">Example 482</a>
+<a href="#example-483">Example 483</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">foo<span class="space"> </span>*****
@@ -15675,9 +15752,9 @@ bim&lt;/em&gt;<span class="space"> </span>bop&lt;/strong&gt;&lt;/p&gt;
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-483">
+<div class="example" id="example-484">
 <div class="examplenum">
-<a href="#example-483">Example 483</a>
+<a href="#example-484">Example 484</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">foo<span class="space"> </span>**\***
@@ -15688,9 +15765,9 @@ bim&lt;/em&gt;<span class="space"> </span>bop&lt;/strong&gt;&lt;/p&gt;
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-484">
+<div class="example" id="example-485">
 <div class="examplenum">
-<a href="#example-484">Example 484</a>
+<a href="#example-485">Example 485</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">foo<span class="space"> </span>**_**
@@ -15704,9 +15781,9 @@ bim&lt;/em&gt;<span class="space"> </span>bop&lt;/strong&gt;&lt;/p&gt;
 <p>Note that when delimiters do not match evenly, Rule 11 determines
 that the excess literal <code>*</code> characters will appear outside of the
 emphasis, rather than inside it:</p>
-<div class="example" id="example-485">
+<div class="example" id="example-486">
 <div class="examplenum">
-<a href="#example-485">Example 485</a>
+<a href="#example-486">Example 486</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">**foo*
@@ -15717,9 +15794,9 @@ emphasis, rather than inside it:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-486">
+<div class="example" id="example-487">
 <div class="examplenum">
-<a href="#example-486">Example 486</a>
+<a href="#example-487">Example 487</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">*foo**
@@ -15730,9 +15807,9 @@ emphasis, rather than inside it:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-487">
+<div class="example" id="example-488">
 <div class="examplenum">
-<a href="#example-487">Example 487</a>
+<a href="#example-488">Example 488</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">***foo**
@@ -15743,9 +15820,9 @@ emphasis, rather than inside it:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-488">
+<div class="example" id="example-489">
 <div class="examplenum">
-<a href="#example-488">Example 488</a>
+<a href="#example-489">Example 489</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">****foo*
@@ -15756,9 +15833,9 @@ emphasis, rather than inside it:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-489">
+<div class="example" id="example-490">
 <div class="examplenum">
-<a href="#example-489">Example 489</a>
+<a href="#example-490">Example 490</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">**foo***
@@ -15769,9 +15846,9 @@ emphasis, rather than inside it:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-490">
+<div class="example" id="example-491">
 <div class="examplenum">
-<a href="#example-490">Example 490</a>
+<a href="#example-491">Example 491</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">*foo****
@@ -15783,9 +15860,9 @@ emphasis, rather than inside it:</p>
 </div>
 </div>
 <p>Rule 12:</p>
-<div class="example" id="example-491">
+<div class="example" id="example-492">
 <div class="examplenum">
-<a href="#example-491">Example 491</a>
+<a href="#example-492">Example 492</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">foo<span class="space"> </span>___
@@ -15796,9 +15873,9 @@ emphasis, rather than inside it:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-492">
+<div class="example" id="example-493">
 <div class="examplenum">
-<a href="#example-492">Example 492</a>
+<a href="#example-493">Example 493</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">foo<span class="space"> </span>_\__
@@ -15809,9 +15886,9 @@ emphasis, rather than inside it:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-493">
+<div class="example" id="example-494">
 <div class="examplenum">
-<a href="#example-493">Example 493</a>
+<a href="#example-494">Example 494</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">foo<span class="space"> </span>_*_
@@ -15822,22 +15899,25 @@ emphasis, rather than inside it:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-494">
+<div class="example" id="example-495">
 <div class="examplenum">
-<a href="#example-494">Example 494</a>
+<a href="#example-495">Example 495</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">foo<span class="space"> </span>_____
 </code></pre>
 </div>
 <div class="column">
-<pre><code class="language-html">&lt;p&gt;foo<span class="space"> </span>_____&lt;/p&gt;
+<pre><code class="language-html">&lt;p&gt;foo<span class="space"> </span>&lt;span<span class="space"> </span>class=&quot;blank&quot;&gt;_____&lt;/span&gt;&lt;/p&gt;
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-495">
+<p>(As above, in CommonMark the <code>_____</code> would render as five literal
+underscores; in Markua, an isolated run of four or more underscores is a
+<a href="#blanks-m-">blank</a>.)</p>
+<div class="example" id="example-496">
 <div class="examplenum">
-<a href="#example-495">Example 495</a>
+<a href="#example-496">Example 496</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">foo<span class="space"> </span>__\___
@@ -15848,9 +15928,9 @@ emphasis, rather than inside it:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-496">
+<div class="example" id="example-497">
 <div class="examplenum">
-<a href="#example-496">Example 496</a>
+<a href="#example-497">Example 497</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">foo<span class="space"> </span>__*__
@@ -15861,9 +15941,9 @@ emphasis, rather than inside it:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-497">
+<div class="example" id="example-498">
 <div class="examplenum">
-<a href="#example-497">Example 497</a>
+<a href="#example-498">Example 498</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">__foo_
@@ -15877,9 +15957,9 @@ emphasis, rather than inside it:</p>
 <p>Note that when delimiters do not match evenly, Rule 12 determines
 that the excess literal <code>_</code> characters will appear outside of the
 emphasis, rather than inside it:</p>
-<div class="example" id="example-498">
+<div class="example" id="example-499">
 <div class="examplenum">
-<a href="#example-498">Example 498</a>
+<a href="#example-499">Example 499</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">_foo__
@@ -15890,9 +15970,9 @@ emphasis, rather than inside it:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-499">
+<div class="example" id="example-500">
 <div class="examplenum">
-<a href="#example-499">Example 499</a>
+<a href="#example-500">Example 500</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">___foo__
@@ -15903,9 +15983,9 @@ emphasis, rather than inside it:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-500">
+<div class="example" id="example-501">
 <div class="examplenum">
-<a href="#example-500">Example 500</a>
+<a href="#example-501">Example 501</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">____foo_
@@ -15916,9 +15996,9 @@ emphasis, rather than inside it:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-501">
+<div class="example" id="example-502">
 <div class="examplenum">
-<a href="#example-501">Example 501</a>
+<a href="#example-502">Example 502</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">__foo___
@@ -15929,9 +16009,9 @@ emphasis, rather than inside it:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-502">
+<div class="example" id="example-503">
 <div class="examplenum">
-<a href="#example-502">Example 502</a>
+<a href="#example-503">Example 503</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">_foo____
@@ -15944,9 +16024,9 @@ emphasis, rather than inside it:</p>
 </div>
 <p>Rule 13 implies that if you want emphasis nested directly inside
 emphasis, you must use different delimiters:</p>
-<div class="example" id="example-503">
+<div class="example" id="example-504">
 <div class="examplenum">
-<a href="#example-503">Example 503</a>
+<a href="#example-504">Example 504</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">**foo**
@@ -15957,9 +16037,9 @@ emphasis, you must use different delimiters:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-504">
+<div class="example" id="example-505">
 <div class="examplenum">
-<a href="#example-504">Example 504</a>
+<a href="#example-505">Example 505</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">*_foo_*
@@ -15970,9 +16050,9 @@ emphasis, you must use different delimiters:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-505">
+<div class="example" id="example-506">
 <div class="examplenum">
-<a href="#example-505">Example 505</a>
+<a href="#example-506">Example 506</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">__foo__
@@ -15983,9 +16063,9 @@ emphasis, you must use different delimiters:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-506">
+<div class="example" id="example-507">
 <div class="examplenum">
-<a href="#example-506">Example 506</a>
+<a href="#example-507">Example 507</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">_*foo*_
@@ -15998,9 +16078,9 @@ emphasis, you must use different delimiters:</p>
 </div>
 <p>However, strong emphasis within strong emphasis is possible without
 switching delimiters:</p>
-<div class="example" id="example-507">
+<div class="example" id="example-508">
 <div class="examplenum">
-<a href="#example-507">Example 507</a>
+<a href="#example-508">Example 508</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">****foo****
@@ -16011,9 +16091,9 @@ switching delimiters:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-508">
+<div class="example" id="example-509">
 <div class="examplenum">
-<a href="#example-508">Example 508</a>
+<a href="#example-509">Example 509</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">____foo____
@@ -16026,9 +16106,9 @@ switching delimiters:</p>
 </div>
 <p>Rule 13 can be applied to arbitrarily long sequences of
 delimiters:</p>
-<div class="example" id="example-509">
+<div class="example" id="example-510">
 <div class="examplenum">
-<a href="#example-509">Example 509</a>
+<a href="#example-510">Example 510</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">******foo******
@@ -16040,9 +16120,9 @@ delimiters:</p>
 </div>
 </div>
 <p>Rule 14:</p>
-<div class="example" id="example-510">
+<div class="example" id="example-511">
 <div class="examplenum">
-<a href="#example-510">Example 510</a>
+<a href="#example-511">Example 511</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">***foo***
@@ -16053,9 +16133,9 @@ delimiters:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-511">
+<div class="example" id="example-512">
 <div class="examplenum">
-<a href="#example-511">Example 511</a>
+<a href="#example-512">Example 512</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">_____foo_____
@@ -16067,9 +16147,9 @@ delimiters:</p>
 </div>
 </div>
 <p>Rule 15:</p>
-<div class="example" id="example-512">
+<div class="example" id="example-513">
 <div class="examplenum">
-<a href="#example-512">Example 512</a>
+<a href="#example-513">Example 513</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">*foo<span class="space"> </span>_bar*<span class="space"> </span>baz_
@@ -16080,9 +16160,9 @@ delimiters:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-513">
+<div class="example" id="example-514">
 <div class="examplenum">
-<a href="#example-513">Example 513</a>
+<a href="#example-514">Example 514</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">*foo<span class="space"> </span>__bar<span class="space"> </span>*baz<span class="space"> </span>bim__<span class="space"> </span>bam*
@@ -16094,9 +16174,9 @@ delimiters:</p>
 </div>
 </div>
 <p>Rule 16:</p>
-<div class="example" id="example-514">
+<div class="example" id="example-515">
 <div class="examplenum">
-<a href="#example-514">Example 514</a>
+<a href="#example-515">Example 515</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">**foo<span class="space"> </span>**bar<span class="space"> </span>baz**
@@ -16107,9 +16187,9 @@ delimiters:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-515">
+<div class="example" id="example-516">
 <div class="examplenum">
-<a href="#example-515">Example 515</a>
+<a href="#example-516">Example 516</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">*foo<span class="space"> </span>*bar<span class="space"> </span>baz*
@@ -16121,9 +16201,9 @@ delimiters:</p>
 </div>
 </div>
 <p>Rule 17:</p>
-<div class="example" id="example-516">
+<div class="example" id="example-517">
 <div class="examplenum">
-<a href="#example-516">Example 516</a>
+<a href="#example-517">Example 517</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">*[bar*](/url)
@@ -16134,9 +16214,9 @@ delimiters:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-517">
+<div class="example" id="example-518">
 <div class="examplenum">
-<a href="#example-517">Example 517</a>
+<a href="#example-518">Example 518</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">_foo<span class="space"> </span>[bar_](/url)
@@ -16147,9 +16227,9 @@ delimiters:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-518">
+<div class="example" id="example-519">
 <div class="examplenum">
-<a href="#example-518">Example 518</a>
+<a href="#example-519">Example 519</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">*&lt;img<span class="space"> </span>src=&quot;foo&quot;<span class="space"> </span>title=&quot;*&quot;/&gt;
@@ -16160,9 +16240,9 @@ delimiters:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-519">
+<div class="example" id="example-520">
 <div class="examplenum">
-<a href="#example-519">Example 519</a>
+<a href="#example-520">Example 520</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">**&lt;a<span class="space"> </span>href=&quot;**&quot;&gt;
@@ -16173,9 +16253,9 @@ delimiters:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-520">
+<div class="example" id="example-521">
 <div class="examplenum">
-<a href="#example-520">Example 520</a>
+<a href="#example-521">Example 521</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">__&lt;a<span class="space"> </span>href=&quot;__&quot;&gt;
@@ -16186,9 +16266,9 @@ delimiters:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-521">
+<div class="example" id="example-522">
 <div class="examplenum">
-<a href="#example-521">Example 521</a>
+<a href="#example-522">Example 522</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">*a<span class="space"> </span>`*`*
@@ -16199,9 +16279,9 @@ delimiters:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-522">
+<div class="example" id="example-523">
 <div class="examplenum">
-<a href="#example-522">Example 522</a>
+<a href="#example-523">Example 523</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">_a<span class="space"> </span>`_`_
@@ -16212,9 +16292,9 @@ delimiters:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-523">
+<div class="example" id="example-524">
 <div class="examplenum">
-<a href="#example-523">Example 523</a>
+<a href="#example-524">Example 524</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">**a&lt;https://foo.bar/?q=**&gt;
@@ -16225,9 +16305,9 @@ delimiters:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-524">
+<div class="example" id="example-525">
 <div class="examplenum">
-<a href="#example-524">Example 524</a>
+<a href="#example-525">Example 525</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">__a&lt;https://foo.bar/?q=__&gt;
@@ -16326,9 +16406,9 @@ above.  The link’s title consists of the link title, excluding its
 enclosing delimiters, with backslash-escapes in effect as described
 above.</p>
 <p>Here is a simple inline link:</p>
-<div class="example" id="example-525">
+<div class="example" id="example-526">
 <div class="examplenum">
-<a href="#example-525">Example 525</a>
+<a href="#example-526">Example 526</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[link](/uri<span class="space"> </span>&quot;title&quot;)
@@ -16341,9 +16421,9 @@ above.</p>
 </div>
 <p>The title, the link text and even
 the destination may be omitted:</p>
-<div class="example" id="example-526">
+<div class="example" id="example-527">
 <div class="examplenum">
-<a href="#example-526">Example 526</a>
+<a href="#example-527">Example 527</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[link](/uri)
@@ -16354,9 +16434,9 @@ the destination may be omitted:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-527">
+<div class="example" id="example-528">
 <div class="examplenum">
-<a href="#example-527">Example 527</a>
+<a href="#example-528">Example 528</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[](./target.md)
@@ -16367,25 +16447,12 @@ the destination may be omitted:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-528">
-<div class="examplenum">
-<a href="#example-528">Example 528</a>
-</div>
-<div class="column">
-<pre><code class="language-markdown">[link]()
-</code></pre>
-</div>
-<div class="column">
-<pre><code class="language-html">&lt;p&gt;&lt;a<span class="space"> </span>href=&quot;&quot;&gt;link&lt;/a&gt;&lt;/p&gt;
-</code></pre>
-</div>
-</div>
 <div class="example" id="example-529">
 <div class="examplenum">
 <a href="#example-529">Example 529</a>
 </div>
 <div class="column">
-<pre><code class="language-markdown">[link](&lt;&gt;)
+<pre><code class="language-markdown">[link]()
 </code></pre>
 </div>
 <div class="column">
@@ -16398,6 +16465,19 @@ the destination may be omitted:</p>
 <a href="#example-530">Example 530</a>
 </div>
 <div class="column">
+<pre><code class="language-markdown">[link](&lt;&gt;)
+</code></pre>
+</div>
+<div class="column">
+<pre><code class="language-html">&lt;p&gt;&lt;a<span class="space"> </span>href=&quot;&quot;&gt;link&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+</div>
+</div>
+<div class="example" id="example-531">
+<div class="examplenum">
+<a href="#example-531">Example 531</a>
+</div>
+<div class="column">
 <pre><code class="language-markdown">[]()
 </code></pre>
 </div>
@@ -16408,9 +16488,9 @@ the destination may be omitted:</p>
 </div>
 <p>The destination can only contain spaces if it is
 enclosed in pointy brackets:</p>
-<div class="example" id="example-531">
+<div class="example" id="example-532">
 <div class="examplenum">
-<a href="#example-531">Example 531</a>
+<a href="#example-532">Example 532</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[link](/my<span class="space"> </span>uri)
@@ -16421,9 +16501,9 @@ enclosed in pointy brackets:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-532">
+<div class="example" id="example-533">
 <div class="examplenum">
-<a href="#example-532">Example 532</a>
+<a href="#example-533">Example 533</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[link](&lt;/my<span class="space"> </span>uri&gt;)
@@ -16436,9 +16516,9 @@ enclosed in pointy brackets:</p>
 </div>
 <p>The destination cannot contain line endings,
 even if enclosed in pointy brackets:</p>
-<div class="example" id="example-533">
+<div class="example" id="example-534">
 <div class="examplenum">
-<a href="#example-533">Example 533</a>
+<a href="#example-534">Example 534</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[link](foo
@@ -16451,9 +16531,9 @@ bar)&lt;/p&gt;
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-534">
+<div class="example" id="example-535">
 <div class="examplenum">
-<a href="#example-534">Example 534</a>
+<a href="#example-535">Example 535</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[link](&lt;foo
@@ -16468,9 +16548,9 @@ bar&gt;)&lt;/p&gt;
 </div>
 <p>The destination can contain <code>)</code> if it is enclosed
 in pointy brackets:</p>
-<div class="example" id="example-535">
+<div class="example" id="example-536">
 <div class="examplenum">
-<a href="#example-535">Example 535</a>
+<a href="#example-536">Example 536</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[a](&lt;b)c&gt;)
@@ -16482,9 +16562,9 @@ in pointy brackets:</p>
 </div>
 </div>
 <p>Pointy brackets that enclose links must be unescaped:</p>
-<div class="example" id="example-536">
+<div class="example" id="example-537">
 <div class="examplenum">
-<a href="#example-536">Example 536</a>
+<a href="#example-537">Example 537</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[link](&lt;foo\&gt;)
@@ -16497,9 +16577,9 @@ in pointy brackets:</p>
 </div>
 <p>These are not links, because the opening pointy bracket
 is not matched properly:</p>
-<div class="example" id="example-537">
+<div class="example" id="example-538">
 <div class="examplenum">
-<a href="#example-537">Example 537</a>
+<a href="#example-538">Example 538</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[a](&lt;b)c
@@ -16515,9 +16595,9 @@ is not matched properly:</p>
 </div>
 </div>
 <p>Parentheses inside the link destination may be escaped:</p>
-<div class="example" id="example-538">
+<div class="example" id="example-539">
 <div class="examplenum">
-<a href="#example-538">Example 538</a>
+<a href="#example-539">Example 539</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[link](\(foo\))
@@ -16530,9 +16610,9 @@ is not matched properly:</p>
 </div>
 <p>Any number of parentheses are allowed without escaping, as long as they are
 balanced:</p>
-<div class="example" id="example-539">
+<div class="example" id="example-540">
 <div class="examplenum">
-<a href="#example-539">Example 539</a>
+<a href="#example-540">Example 540</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[link](foo(and(bar)))
@@ -16545,9 +16625,9 @@ balanced:</p>
 </div>
 <p>However, if you have unbalanced parentheses, you need to escape or use the
 <code>&lt;...&gt;</code> form:</p>
-<div class="example" id="example-540">
+<div class="example" id="example-541">
 <div class="examplenum">
-<a href="#example-540">Example 540</a>
+<a href="#example-541">Example 541</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[link](foo(and(bar))
@@ -16558,9 +16638,9 @@ balanced:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-541">
+<div class="example" id="example-542">
 <div class="examplenum">
-<a href="#example-541">Example 541</a>
+<a href="#example-542">Example 542</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[link](foo\(and\(bar\))
@@ -16571,9 +16651,9 @@ balanced:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-542">
+<div class="example" id="example-543">
 <div class="examplenum">
-<a href="#example-542">Example 542</a>
+<a href="#example-543">Example 543</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[link](&lt;foo(and(bar)&gt;)
@@ -16586,9 +16666,9 @@ balanced:</p>
 </div>
 <p>Parentheses and other symbols can also be escaped, as usual
 in Markdown:</p>
-<div class="example" id="example-543">
+<div class="example" id="example-544">
 <div class="examplenum">
-<a href="#example-543">Example 543</a>
+<a href="#example-544">Example 544</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[link](foo\)\:)
@@ -16600,9 +16680,9 @@ in Markdown:</p>
 </div>
 </div>
 <p>A link can contain fragment identifiers and queries:</p>
-<div class="example" id="example-544">
+<div class="example" id="example-545">
 <div class="examplenum">
-<a href="#example-544">Example 544</a>
+<a href="#example-545">Example 545</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[link](#fragment)
@@ -16621,9 +16701,9 @@ in Markdown:</p>
 </div>
 <p>Note that a backslash before a non-escapable character is
 just a backslash:</p>
-<div class="example" id="example-545">
+<div class="example" id="example-546">
 <div class="examplenum">
-<a href="#example-545">Example 545</a>
+<a href="#example-546">Example 546</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[link](foo\bar)
@@ -16642,9 +16722,9 @@ be optionally URL-escaped when written as HTML, but this spec
 does not enforce any particular policy for rendering URLs in
 HTML or other formats.  Renderers may make different decisions
 about how to escape or normalize URLs in the output.</p>
-<div class="example" id="example-546">
+<div class="example" id="example-547">
 <div class="examplenum">
-<a href="#example-546">Example 546</a>
+<a href="#example-547">Example 547</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[link](foo%20b&amp;auml;)
@@ -16658,9 +16738,9 @@ about how to escape or normalize URLs in the output.</p>
 <p>Note that, because titles can often be parsed as destinations,
 if you try to omit the destination and keep the title, you’ll
 get unexpected results:</p>
-<div class="example" id="example-547">
+<div class="example" id="example-548">
 <div class="examplenum">
-<a href="#example-547">Example 547</a>
+<a href="#example-548">Example 548</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[link](&quot;title&quot;)
@@ -16672,9 +16752,9 @@ get unexpected results:</p>
 </div>
 </div>
 <p>Titles may be in single quotes, double quotes, or parentheses:</p>
-<div class="example" id="example-548">
+<div class="example" id="example-549">
 <div class="examplenum">
-<a href="#example-548">Example 548</a>
+<a href="#example-549">Example 549</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[link](/url<span class="space"> </span>&quot;title&quot;)
@@ -16691,9 +16771,9 @@ get unexpected results:</p>
 </div>
 <p>Backslash escapes and entity and numeric character references
 may be used in titles:</p>
-<div class="example" id="example-549">
+<div class="example" id="example-550">
 <div class="examplenum">
-<a href="#example-549">Example 549</a>
+<a href="#example-550">Example 550</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[link](/url<span class="space"> </span>&quot;title<span class="space"> </span>\&quot;&amp;quot;&quot;)
@@ -16707,9 +16787,9 @@ may be used in titles:</p>
 <p>Titles must be separated from the link using spaces, tabs, and up to one line
 ending.
 Other <a href="#unicode-whitespace">Unicode whitespace</a> like non-breaking space doesn’t work.</p>
-<div class="example" id="example-550">
+<div class="example" id="example-551">
 <div class="examplenum">
-<a href="#example-550">Example 550</a>
+<a href="#example-551">Example 551</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[link](/url &quot;title&quot;)
@@ -16721,9 +16801,9 @@ Other <a href="#unicode-whitespace">Unicode whitespace</a> like non-breaking spa
 </div>
 </div>
 <p>Nested balanced quotes are not allowed without escaping:</p>
-<div class="example" id="example-551">
+<div class="example" id="example-552">
 <div class="examplenum">
-<a href="#example-551">Example 551</a>
+<a href="#example-552">Example 552</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[link](/url<span class="space"> </span>&quot;title<span class="space"> </span>&quot;and&quot;<span class="space"> </span>title&quot;)
@@ -16735,9 +16815,9 @@ Other <a href="#unicode-whitespace">Unicode whitespace</a> like non-breaking spa
 </div>
 </div>
 <p>But it is easy to work around this by using a different quote type:</p>
-<div class="example" id="example-552">
+<div class="example" id="example-553">
 <div class="examplenum">
-<a href="#example-552">Example 552</a>
+<a href="#example-553">Example 553</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[link](/url<span class="space"> </span>'title<span class="space"> </span>&quot;and&quot;<span class="space"> </span>title')
@@ -16764,9 +16844,9 @@ It seems preferable to adopt a simple, rational rule that works
 the same way in inline links and link reference definitions.)</p>
 <p>Spaces, tabs, and up to one line ending is allowed around the destination and
 title:</p>
-<div class="example" id="example-553">
+<div class="example" id="example-554">
 <div class="examplenum">
-<a href="#example-553">Example 553</a>
+<a href="#example-554">Example 554</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[link](<span class="space"> </span><span class="space"> </span><span class="space"> </span>/uri
@@ -16780,9 +16860,9 @@ title:</p>
 </div>
 <p>But it is not allowed between the link text and the
 following parenthesis:</p>
-<div class="example" id="example-554">
+<div class="example" id="example-555">
 <div class="examplenum">
-<a href="#example-554">Example 554</a>
+<a href="#example-555">Example 555</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[link]<span class="space"> </span>(/uri)
@@ -16795,9 +16875,9 @@ following parenthesis:</p>
 </div>
 <p>The link text may contain balanced brackets, but not unbalanced ones,
 unless they are escaped:</p>
-<div class="example" id="example-555">
+<div class="example" id="example-556">
 <div class="examplenum">
-<a href="#example-555">Example 555</a>
+<a href="#example-556">Example 556</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[link<span class="space"> </span>[foo<span class="space"> </span>[bar]]](/uri)
@@ -16808,9 +16888,9 @@ unless they are escaped:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-556">
+<div class="example" id="example-557">
 <div class="examplenum">
-<a href="#example-556">Example 556</a>
+<a href="#example-557">Example 557</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[link]<span class="space"> </span>bar](/uri)
@@ -16821,9 +16901,9 @@ unless they are escaped:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-557">
+<div class="example" id="example-558">
 <div class="examplenum">
-<a href="#example-557">Example 557</a>
+<a href="#example-558">Example 558</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[link<span class="space"> </span>[bar](/uri)
@@ -16834,9 +16914,9 @@ unless they are escaped:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-558">
+<div class="example" id="example-559">
 <div class="examplenum">
-<a href="#example-558">Example 558</a>
+<a href="#example-559">Example 559</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[link<span class="space"> </span>\[bar](/uri)
@@ -16848,9 +16928,9 @@ unless they are escaped:</p>
 </div>
 </div>
 <p>The link text may contain inline content:</p>
-<div class="example" id="example-559">
+<div class="example" id="example-560">
 <div class="examplenum">
-<a href="#example-559">Example 559</a>
+<a href="#example-560">Example 560</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[link<span class="space"> </span>*foo<span class="space"> </span>**bar**<span class="space"> </span>`#`*](/uri)
@@ -16861,9 +16941,9 @@ unless they are escaped:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-560">
+<div class="example" id="example-561">
 <div class="examplenum">
-<a href="#example-560">Example 560</a>
+<a href="#example-561">Example 561</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[![moon](moon.jpg)](/uri)
@@ -16875,9 +16955,9 @@ unless they are escaped:</p>
 </div>
 </div>
 <p>However, links may not contain other links, at any level of nesting.</p>
-<div class="example" id="example-561">
+<div class="example" id="example-562">
 <div class="examplenum">
-<a href="#example-561">Example 561</a>
+<a href="#example-562">Example 562</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[foo<span class="space"> </span>[bar](/uri)](/uri)
@@ -16888,9 +16968,9 @@ unless they are escaped:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-562">
+<div class="example" id="example-563">
 <div class="examplenum">
-<a href="#example-562">Example 562</a>
+<a href="#example-563">Example 563</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[foo<span class="space"> </span>*[bar<span class="space"> </span>[baz](/uri)](/uri)*](/uri)
@@ -16901,9 +16981,9 @@ unless they are escaped:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-563">
+<div class="example" id="example-564">
 <div class="examplenum">
-<a href="#example-563">Example 563</a>
+<a href="#example-564">Example 564</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">![[[foo](uri1)](uri2)](uri3)
@@ -16916,9 +16996,9 @@ unless they are escaped:</p>
 </div>
 <p>These cases illustrate the precedence of link text grouping over
 emphasis grouping:</p>
-<div class="example" id="example-564">
+<div class="example" id="example-565">
 <div class="examplenum">
-<a href="#example-564">Example 564</a>
+<a href="#example-565">Example 565</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">*[foo*](/uri)
@@ -16929,9 +17009,9 @@ emphasis grouping:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-565">
+<div class="example" id="example-566">
 <div class="examplenum">
-<a href="#example-565">Example 565</a>
+<a href="#example-566">Example 566</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[foo<span class="space"> </span>*bar](baz*)
@@ -16944,9 +17024,9 @@ emphasis grouping:</p>
 </div>
 <p>Note that brackets that <em>aren’t</em> part of links do not take
 precedence:</p>
-<div class="example" id="example-566">
+<div class="example" id="example-567">
 <div class="examplenum">
-<a href="#example-566">Example 566</a>
+<a href="#example-567">Example 567</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">*foo<span class="space"> </span>[bar*<span class="space"> </span>baz]
@@ -16959,9 +17039,9 @@ precedence:</p>
 </div>
 <p>These cases illustrate the precedence of HTML tags, code spans,
 and autolinks over link grouping:</p>
-<div class="example" id="example-567">
+<div class="example" id="example-568">
 <div class="examplenum">
-<a href="#example-567">Example 567</a>
+<a href="#example-568">Example 568</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[foo<span class="space"> </span>&lt;bar<span class="space"> </span>attr=&quot;](baz)&quot;&gt;
@@ -16972,9 +17052,9 @@ and autolinks over link grouping:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-568">
+<div class="example" id="example-569">
 <div class="examplenum">
-<a href="#example-568">Example 568</a>
+<a href="#example-569">Example 569</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[foo`](/uri)`
@@ -16985,9 +17065,9 @@ and autolinks over link grouping:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-569">
+<div class="example" id="example-570">
 <div class="examplenum">
-<a href="#example-569">Example 569</a>
+<a href="#example-570">Example 570</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[foo&lt;https://example.com/?search=](uri)&gt;
@@ -17023,9 +17103,9 @@ document is used.  (It is desirable in such cases to emit a warning.)</p>
 <p>The link’s URI and title are provided by the matching <a href="#link-reference-definition">link
 reference definition</a>.</p>
 <p>Here is a simple example:</p>
-<div class="example" id="example-570">
+<div class="example" id="example-571">
 <div class="examplenum">
-<a href="#example-570">Example 570</a>
+<a href="#example-571">Example 571</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[foo][bar]
@@ -17042,9 +17122,9 @@ reference definition</a>.</p>
 <a href="#inline-link">inline links</a>.  Thus:</p>
 <p>The link text may contain balanced brackets, but not unbalanced ones,
 unless they are escaped:</p>
-<div class="example" id="example-571">
+<div class="example" id="example-572">
 <div class="examplenum">
-<a href="#example-571">Example 571</a>
+<a href="#example-572">Example 572</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[link<span class="space"> </span>[foo<span class="space"> </span>[bar]]][ref]
@@ -17057,9 +17137,9 @@ unless they are escaped:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-572">
+<div class="example" id="example-573">
 <div class="examplenum">
-<a href="#example-572">Example 572</a>
+<a href="#example-573">Example 573</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[link<span class="space"> </span>\[bar][ref]
@@ -17073,9 +17153,9 @@ unless they are escaped:</p>
 </div>
 </div>
 <p>The link text may contain inline content:</p>
-<div class="example" id="example-573">
+<div class="example" id="example-574">
 <div class="examplenum">
-<a href="#example-573">Example 573</a>
+<a href="#example-574">Example 574</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[link<span class="space"> </span>*foo<span class="space"> </span>**bar**<span class="space"> </span>`#`*][ref]
@@ -17088,9 +17168,9 @@ unless they are escaped:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-574">
+<div class="example" id="example-575">
 <div class="examplenum">
-<a href="#example-574">Example 574</a>
+<a href="#example-575">Example 575</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[![moon](moon.jpg)][ref]
@@ -17104,9 +17184,9 @@ unless they are escaped:</p>
 </div>
 </div>
 <p>However, links may not contain other links, at any level of nesting.</p>
-<div class="example" id="example-575">
+<div class="example" id="example-576">
 <div class="examplenum">
-<a href="#example-575">Example 575</a>
+<a href="#example-576">Example 576</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[foo<span class="space"> </span>[bar](/uri)][ref]
@@ -17119,9 +17199,9 @@ unless they are escaped:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-576">
+<div class="example" id="example-577">
 <div class="examplenum">
-<a href="#example-576">Example 576</a>
+<a href="#example-577">Example 577</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[foo<span class="space"> </span>*bar<span class="space"> </span>[baz][ref]*][ref]
@@ -17138,9 +17218,9 @@ unless they are escaped:</p>
 instead of one <a href="#full-reference-link">full reference link</a>.)</p>
 <p>The following cases illustrate the precedence of link text grouping over
 emphasis grouping:</p>
-<div class="example" id="example-577">
+<div class="example" id="example-578">
 <div class="examplenum">
-<a href="#example-577">Example 577</a>
+<a href="#example-578">Example 578</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">*[foo*][ref]
@@ -17153,9 +17233,9 @@ emphasis grouping:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-578">
+<div class="example" id="example-579">
 <div class="examplenum">
-<a href="#example-578">Example 578</a>
+<a href="#example-579">Example 579</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[foo<span class="space"> </span>*bar][ref]*
@@ -17170,9 +17250,9 @@ emphasis grouping:</p>
 </div>
 <p>These cases illustrate the precedence of HTML tags, code spans,
 and autolinks over link grouping:</p>
-<div class="example" id="example-579">
+<div class="example" id="example-580">
 <div class="examplenum">
-<a href="#example-579">Example 579</a>
+<a href="#example-580">Example 580</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[foo<span class="space"> </span>&lt;bar<span class="space"> </span>attr=&quot;][ref]&quot;&gt;
@@ -17185,9 +17265,9 @@ and autolinks over link grouping:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-580">
+<div class="example" id="example-581">
 <div class="examplenum">
-<a href="#example-580">Example 580</a>
+<a href="#example-581">Example 581</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[foo`][ref]`
@@ -17200,9 +17280,9 @@ and autolinks over link grouping:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-581">
+<div class="example" id="example-582">
 <div class="examplenum">
-<a href="#example-581">Example 581</a>
+<a href="#example-582">Example 582</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[foo&lt;https://example.com/?search=][ref]&gt;
@@ -17216,9 +17296,9 @@ and autolinks over link grouping:</p>
 </div>
 </div>
 <p>Matching is case-insensitive:</p>
-<div class="example" id="example-582">
+<div class="example" id="example-583">
 <div class="examplenum">
-<a href="#example-582">Example 582</a>
+<a href="#example-583">Example 583</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[foo][BaR]
@@ -17232,9 +17312,9 @@ and autolinks over link grouping:</p>
 </div>
 </div>
 <p>Unicode case fold is used:</p>
-<div class="example" id="example-583">
+<div class="example" id="example-584">
 <div class="examplenum">
-<a href="#example-583">Example 583</a>
+<a href="#example-584">Example 584</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[ẞ]
@@ -17249,9 +17329,9 @@ and autolinks over link grouping:</p>
 </div>
 <p>Consecutive internal spaces, tabs, and line endings are treated as one space for
 purposes of determining matching:</p>
-<div class="example" id="example-584">
+<div class="example" id="example-585">
 <div class="examplenum">
-<a href="#example-584">Example 584</a>
+<a href="#example-585">Example 585</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[Foo
@@ -17267,9 +17347,9 @@ purposes of determining matching:</p>
 </div>
 <p>No spaces, tabs, or line endings are allowed between the <a href="#link-text">link text</a> and the
 <a href="#link-label">link label</a>:</p>
-<div class="example" id="example-585">
+<div class="example" id="example-586">
 <div class="examplenum">
-<a href="#example-585">Example 585</a>
+<a href="#example-586">Example 586</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[foo]<span class="space"> </span>[bar]
@@ -17282,9 +17362,9 @@ purposes of determining matching:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-586">
+<div class="example" id="example-587">
 <div class="examplenum">
-<a href="#example-586">Example 586</a>
+<a href="#example-587">Example 587</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[foo]
@@ -17324,9 +17404,9 @@ too dangerous to allow this, as it frequently leads to
 unintended results.)</p>
 <p>When there are multiple matching <a href="#link-reference-definitions">link reference definitions</a>,
 the first is used:</p>
-<div class="example" id="example-587">
+<div class="example" id="example-588">
 <div class="examplenum">
-<a href="#example-587">Example 587</a>
+<a href="#example-588">Example 588</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[foo]:<span class="space"> </span>/url1
@@ -17344,9 +17424,9 @@ the first is used:</p>
 <p>Note that matching is performed on normalized strings, not parsed
 inline content.  So the following does not match, even though the
 labels define equivalent inline content:</p>
-<div class="example" id="example-588">
+<div class="example" id="example-589">
 <div class="examplenum">
-<a href="#example-588">Example 588</a>
+<a href="#example-589">Example 589</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[bar][foo\!]
@@ -17361,9 +17441,9 @@ labels define equivalent inline content:</p>
 </div>
 <p><a href="#link-label">Link labels</a> cannot contain brackets, unless they are
 backslash-escaped:</p>
-<div class="example" id="example-589">
+<div class="example" id="example-590">
 <div class="examplenum">
-<a href="#example-589">Example 589</a>
+<a href="#example-590">Example 590</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[foo][ref[]
@@ -17377,9 +17457,9 @@ backslash-escaped:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-590">
+<div class="example" id="example-591">
 <div class="examplenum">
-<a href="#example-590">Example 590</a>
+<a href="#example-591">Example 591</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[foo][ref[bar]]
@@ -17393,9 +17473,9 @@ backslash-escaped:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-591">
+<div class="example" id="example-592">
 <div class="examplenum">
-<a href="#example-591">Example 591</a>
+<a href="#example-592">Example 592</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[[[foo]]]
@@ -17409,9 +17489,9 @@ backslash-escaped:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-592">
+<div class="example" id="example-593">
 <div class="examplenum">
-<a href="#example-592">Example 592</a>
+<a href="#example-593">Example 593</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[foo][ref\[]
@@ -17425,9 +17505,9 @@ backslash-escaped:</p>
 </div>
 </div>
 <p>Note that in this example <code>]</code> is not backslash-escaped:</p>
-<div class="example" id="example-593">
+<div class="example" id="example-594">
 <div class="examplenum">
-<a href="#example-593">Example 593</a>
+<a href="#example-594">Example 594</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[bar\\]:<span class="space"> </span>/uri
@@ -17442,9 +17522,9 @@ backslash-escaped:</p>
 </div>
 <p>A <a href="#link-label">link label</a> must contain at least one character that is not a space, tab, or
 line ending:</p>
-<div class="example" id="example-594">
+<div class="example" id="example-595">
 <div class="examplenum">
-<a href="#example-594">Example 594</a>
+<a href="#example-595">Example 595</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[]
@@ -17458,9 +17538,9 @@ line ending:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-595">
+<div class="example" id="example-596">
 <div class="examplenum">
-<a href="#example-595">Example 595</a>
+<a href="#example-596">Example 596</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[
@@ -17486,9 +17566,9 @@ The contents of the link label are parsed as inlines,
 which are used as the link’s text.  The link’s URI and title are
 provided by the matching reference link definition.  Thus,
 <code>[foo][]</code> is equivalent to <code>[foo][foo]</code>.</p>
-<div class="example" id="example-596">
+<div class="example" id="example-597">
 <div class="examplenum">
-<a href="#example-596">Example 596</a>
+<a href="#example-597">Example 597</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[foo][]
@@ -17501,9 +17581,9 @@ provided by the matching reference link definition.  Thus,
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-597">
+<div class="example" id="example-598">
 <div class="examplenum">
-<a href="#example-597">Example 597</a>
+<a href="#example-598">Example 598</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[*foo*<span class="space"> </span>bar][]
@@ -17517,9 +17597,9 @@ provided by the matching reference link definition.  Thus,
 </div>
 </div>
 <p>The link labels are case-insensitive:</p>
-<div class="example" id="example-598">
+<div class="example" id="example-599">
 <div class="examplenum">
-<a href="#example-598">Example 598</a>
+<a href="#example-599">Example 599</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[Foo][]
@@ -17534,9 +17614,9 @@ provided by the matching reference link definition.  Thus,
 </div>
 <p>As with full reference links, spaces, tabs, or line endings are not
 allowed between the two sets of brackets:</p>
-<div class="example" id="example-599">
+<div class="example" id="example-600">
 <div class="examplenum">
-<a href="#example-599">Example 599</a>
+<a href="#example-600">Example 600</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[foo]<span class="space"> </span>
@@ -17559,9 +17639,9 @@ The contents of the link label are parsed as inlines,
 which are used as the link’s text.  The link’s URI and title
 are provided by the matching link reference definition.
 Thus, <code>[foo]</code> is equivalent to <code>[foo][]</code>.</p>
-<div class="example" id="example-600">
+<div class="example" id="example-601">
 <div class="examplenum">
-<a href="#example-600">Example 600</a>
+<a href="#example-601">Example 601</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[foo]
@@ -17574,9 +17654,9 @@ Thus, <code>[foo]</code> is equivalent to <code>[foo][]</code>.</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-601">
+<div class="example" id="example-602">
 <div class="examplenum">
-<a href="#example-601">Example 601</a>
+<a href="#example-602">Example 602</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[*foo*<span class="space"> </span>bar]
@@ -17589,9 +17669,9 @@ Thus, <code>[foo]</code> is equivalent to <code>[foo][]</code>.</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-602">
+<div class="example" id="example-603">
 <div class="examplenum">
-<a href="#example-602">Example 602</a>
+<a href="#example-603">Example 603</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[[*foo*<span class="space"> </span>bar]]
@@ -17604,9 +17684,9 @@ Thus, <code>[foo]</code> is equivalent to <code>[foo][]</code>.</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-603">
+<div class="example" id="example-604">
 <div class="examplenum">
-<a href="#example-603">Example 603</a>
+<a href="#example-604">Example 604</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[[bar<span class="space"> </span>[foo]
@@ -17620,9 +17700,9 @@ Thus, <code>[foo]</code> is equivalent to <code>[foo][]</code>.</p>
 </div>
 </div>
 <p>The link labels are case-insensitive:</p>
-<div class="example" id="example-604">
+<div class="example" id="example-605">
 <div class="examplenum">
-<a href="#example-604">Example 604</a>
+<a href="#example-605">Example 605</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[Foo]
@@ -17636,9 +17716,9 @@ Thus, <code>[foo]</code> is equivalent to <code>[foo][]</code>.</p>
 </div>
 </div>
 <p>A space after the link text should be preserved:</p>
-<div class="example" id="example-605">
+<div class="example" id="example-606">
 <div class="examplenum">
-<a href="#example-605">Example 605</a>
+<a href="#example-606">Example 606</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[foo]<span class="space"> </span>bar
@@ -17653,9 +17733,9 @@ Thus, <code>[foo]</code> is equivalent to <code>[foo][]</code>.</p>
 </div>
 <p>If you just want bracketed text, you can backslash-escape the
 opening bracket to avoid links:</p>
-<div class="example" id="example-606">
+<div class="example" id="example-607">
 <div class="examplenum">
-<a href="#example-606">Example 606</a>
+<a href="#example-607">Example 607</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">\[foo]
@@ -17670,9 +17750,9 @@ opening bracket to avoid links:</p>
 </div>
 <p>Note that this is a link, because a link label ends with the first
 following closing bracket:</p>
-<div class="example" id="example-607">
+<div class="example" id="example-608">
 <div class="examplenum">
-<a href="#example-607">Example 607</a>
+<a href="#example-608">Example 608</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[foo*]:<span class="space"> </span>/url
@@ -17687,9 +17767,9 @@ following closing bracket:</p>
 </div>
 <p>Full and compact references take precedence over shortcut
 references:</p>
-<div class="example" id="example-608">
+<div class="example" id="example-609">
 <div class="examplenum">
-<a href="#example-608">Example 608</a>
+<a href="#example-609">Example 609</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[foo][bar]
@@ -17703,9 +17783,9 @@ references:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-609">
+<div class="example" id="example-610">
 <div class="examplenum">
-<a href="#example-609">Example 609</a>
+<a href="#example-610">Example 610</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[foo][]
@@ -17719,9 +17799,9 @@ references:</p>
 </div>
 </div>
 <p>Inline links also take precedence:</p>
-<div class="example" id="example-610">
+<div class="example" id="example-611">
 <div class="examplenum">
-<a href="#example-610">Example 610</a>
+<a href="#example-611">Example 611</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[foo]()
@@ -17734,9 +17814,9 @@ references:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-611">
+<div class="example" id="example-612">
 <div class="examplenum">
-<a href="#example-611">Example 611</a>
+<a href="#example-612">Example 612</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[foo](not<span class="space"> </span>a<span class="space"> </span>link)
@@ -17751,9 +17831,9 @@ references:</p>
 </div>
 <p>In the following case <code>[bar][baz]</code> is parsed as a reference,
 <code>[foo]</code> as normal text:</p>
-<div class="example" id="example-612">
+<div class="example" id="example-613">
 <div class="examplenum">
-<a href="#example-612">Example 612</a>
+<a href="#example-613">Example 613</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[foo][bar][baz]
@@ -17768,9 +17848,9 @@ references:</p>
 </div>
 <p>Here, though, <code>[foo][bar]</code> is parsed as a reference, since
 <code>[bar]</code> is defined:</p>
-<div class="example" id="example-613">
+<div class="example" id="example-614">
 <div class="examplenum">
-<a href="#example-613">Example 613</a>
+<a href="#example-614">Example 614</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[foo][bar][baz]
@@ -17786,9 +17866,9 @@ references:</p>
 </div>
 <p>Here <code>[foo]</code> is not parsed as a shortcut reference, because it
 is followed by a link label (even though <code>[bar]</code> is not defined):</p>
-<div class="example" id="example-614">
+<div class="example" id="example-615">
 <div class="examplenum">
-<a href="#example-614">Example 614</a>
+<a href="#example-615">Example 615</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">[foo][bar][baz]
@@ -17889,9 +17969,9 @@ To do this, you use the <code>#</code> character and the id in a link:</p>
 <p>This syntax is intended to be reminiscent of HTML anchor tags.</p>
 <p>Note that order of definition and use does not matter: crosslinks will work
 regardless of whether the <code>id</code> is defined before or after the use of it.</p>
-<div class="example" id="example-615">
+<div class="example" id="example-616">
 <div class="examplenum">
-<a href="#example-615">Example 615</a>
+<a href="#example-616">Example 616</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">{id:<span class="space"> </span>id1}
@@ -18098,9 +18178,9 @@ image description starts with <code>![</code> rather than <code>[</code>, and
 An image description has inline elements
 as its contents.  When an image is rendered to HTML,
 this is standardly used as the image’s <code>alt</code> attribute.</p>
-<div class="example" id="example-616">
+<div class="example" id="example-617">
 <div class="examplenum">
-<a href="#example-616">Example 616</a>
+<a href="#example-617">Example 617</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">![foo](/url<span class="space"> </span>&quot;title&quot;)
@@ -18111,9 +18191,9 @@ this is standardly used as the image’s <code>alt</code> attribute.</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-617">
+<div class="example" id="example-618">
 <div class="examplenum">
-<a href="#example-617">Example 617</a>
+<a href="#example-618">Example 618</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">![foo<span class="space"> </span>*bar*]
@@ -18126,9 +18206,9 @@ this is standardly used as the image’s <code>alt</code> attribute.</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-618">
+<div class="example" id="example-619">
 <div class="examplenum">
-<a href="#example-618">Example 618</a>
+<a href="#example-619">Example 619</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">![foo<span class="space"> </span>![bar](/url)](/url2)
@@ -18139,9 +18219,9 @@ this is standardly used as the image’s <code>alt</code> attribute.</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-619">
+<div class="example" id="example-620">
 <div class="examplenum">
-<a href="#example-619">Example 619</a>
+<a href="#example-620">Example 620</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">![foo<span class="space"> </span>[bar](/url)](/url2)
@@ -18157,9 +18237,9 @@ recommended that in rendering to HTML, only the plain string content
 of the <a href="#image-description">image description</a> be used.  Note that in
 the above example, the alt attribute’s value is <code>foo bar</code>, not <code>foo [bar](/url)</code> or <code>foo &lt;a href=&quot;/url&quot;&gt;bar&lt;/a&gt;</code>.  Only the plain string
 content is rendered, without formatting.</p>
-<div class="example" id="example-620">
+<div class="example" id="example-621">
 <div class="examplenum">
-<a href="#example-620">Example 620</a>
+<a href="#example-621">Example 621</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">![foo<span class="space"> </span>*bar*][]
@@ -18172,9 +18252,9 @@ content is rendered, without formatting.</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-621">
+<div class="example" id="example-622">
 <div class="examplenum">
-<a href="#example-621">Example 621</a>
+<a href="#example-622">Example 622</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">![foo<span class="space"> </span>*bar*][foobar]
@@ -18187,9 +18267,9 @@ content is rendered, without formatting.</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-622">
+<div class="example" id="example-623">
 <div class="examplenum">
-<a href="#example-622">Example 622</a>
+<a href="#example-623">Example 623</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">![foo](train.jpg)
@@ -18200,9 +18280,9 @@ content is rendered, without formatting.</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-623">
+<div class="example" id="example-624">
 <div class="examplenum">
-<a href="#example-623">Example 623</a>
+<a href="#example-624">Example 624</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">My<span class="space"> </span>![foo<span class="space"> </span>bar](/path/to/train.jpg<span class="space"> </span><span class="space"> </span>&quot;title&quot;<span class="space"> </span><span class="space"> </span><span class="space"> </span>)
@@ -18213,9 +18293,9 @@ content is rendered, without formatting.</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-624">
+<div class="example" id="example-625">
 <div class="examplenum">
-<a href="#example-624">Example 624</a>
+<a href="#example-625">Example 625</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">![foo](&lt;url&gt;)
@@ -18226,9 +18306,9 @@ content is rendered, without formatting.</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-625">
+<div class="example" id="example-626">
 <div class="examplenum">
-<a href="#example-625">Example 625</a>
+<a href="#example-626">Example 626</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">![](/url)
@@ -18240,9 +18320,9 @@ content is rendered, without formatting.</p>
 </div>
 </div>
 <p>Reference-style:</p>
-<div class="example" id="example-626">
+<div class="example" id="example-627">
 <div class="examplenum">
-<a href="#example-626">Example 626</a>
+<a href="#example-627">Example 627</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">![foo][bar]
@@ -18255,9 +18335,9 @@ content is rendered, without formatting.</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-627">
+<div class="example" id="example-628">
 <div class="examplenum">
-<a href="#example-627">Example 627</a>
+<a href="#example-628">Example 628</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">![foo][bar]
@@ -18271,9 +18351,9 @@ content is rendered, without formatting.</p>
 </div>
 </div>
 <p>Collapsed:</p>
-<div class="example" id="example-628">
+<div class="example" id="example-629">
 <div class="examplenum">
-<a href="#example-628">Example 628</a>
+<a href="#example-629">Example 629</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">![foo][]
@@ -18286,9 +18366,9 @@ content is rendered, without formatting.</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-629">
+<div class="example" id="example-630">
 <div class="examplenum">
-<a href="#example-629">Example 629</a>
+<a href="#example-630">Example 630</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">![*foo*<span class="space"> </span>bar][]
@@ -18302,9 +18382,9 @@ content is rendered, without formatting.</p>
 </div>
 </div>
 <p>The labels are case-insensitive:</p>
-<div class="example" id="example-630">
+<div class="example" id="example-631">
 <div class="examplenum">
-<a href="#example-630">Example 630</a>
+<a href="#example-631">Example 631</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">![Foo][]
@@ -18319,9 +18399,9 @@ content is rendered, without formatting.</p>
 </div>
 <p>As with reference links, spaces, tabs, and line endings, are not allowed
 between the two sets of brackets:</p>
-<div class="example" id="example-631">
+<div class="example" id="example-632">
 <div class="examplenum">
-<a href="#example-631">Example 631</a>
+<a href="#example-632">Example 632</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">![foo]<span class="space"> </span>
@@ -18337,9 +18417,9 @@ between the two sets of brackets:</p>
 </div>
 </div>
 <p>Shortcut:</p>
-<div class="example" id="example-632">
+<div class="example" id="example-633">
 <div class="examplenum">
-<a href="#example-632">Example 632</a>
+<a href="#example-633">Example 633</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">![foo]
@@ -18352,9 +18432,9 @@ between the two sets of brackets:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-633">
+<div class="example" id="example-634">
 <div class="examplenum">
-<a href="#example-633">Example 633</a>
+<a href="#example-634">Example 634</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">![*foo*<span class="space"> </span>bar]
@@ -18368,9 +18448,9 @@ between the two sets of brackets:</p>
 </div>
 </div>
 <p>Note that link labels cannot contain unescaped brackets:</p>
-<div class="example" id="example-634">
+<div class="example" id="example-635">
 <div class="examplenum">
-<a href="#example-634">Example 634</a>
+<a href="#example-635">Example 635</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">![[foo]]
@@ -18385,9 +18465,9 @@ between the two sets of brackets:</p>
 </div>
 </div>
 <p>The link labels are case-insensitive:</p>
-<div class="example" id="example-635">
+<div class="example" id="example-636">
 <div class="examplenum">
-<a href="#example-635">Example 635</a>
+<a href="#example-636">Example 636</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">![Foo]
@@ -18402,9 +18482,9 @@ between the two sets of brackets:</p>
 </div>
 <p>If you just want a literal <code>!</code> followed by bracketed text, you can
 backslash-escape the opening <code>[</code>:</p>
-<div class="example" id="example-636">
+<div class="example" id="example-637">
 <div class="examplenum">
-<a href="#example-636">Example 636</a>
+<a href="#example-637">Example 637</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">!\[foo]
@@ -18419,9 +18499,9 @@ backslash-escape the opening <code>[</code>:</p>
 </div>
 <p>If you want a link after a literal <code>!</code>, backslash-escape the
 <code>!</code>:</p>
-<div class="example" id="example-637">
+<div class="example" id="example-638">
 <div class="examplenum">
-<a href="#example-637">Example 637</a>
+<a href="#example-638">Example 638</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">\![foo]
@@ -18538,9 +18618,9 @@ Processor should scale the image proportionally if possible (again, respecting
 margins). If both <code>width</code> and <code>height</code> are specified, the Markua Processor
 should scale the image accordingly, ignoring the aspect ratio. (So, it’s almost
 always a bad idea to specify both <code>width</code> and <code>height</code>.)</p>
-<div class="example" id="example-638">
+<div class="example" id="example-639">
 <div class="examplenum">
-<a href="#example-638">Example 638</a>
+<a href="#example-639">Example 639</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">![foo](pie.jpg)
@@ -18559,9 +18639,9 @@ always a bad idea to specify both <code>width</code> and <code>height</code>.)</
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-639">
+<div class="example" id="example-640">
 <div class="examplenum">
-<a href="#example-639">Example 639</a>
+<a href="#example-640">Example 640</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">![foo](pie.jpg<span class="space"> </span>&quot;bar&quot;)
@@ -18912,9 +18992,9 @@ over how it handles the location of video resources and their display.</p>
 <h3 id="local-video" class="definition">
 <span class="number">11.11.2</span>Local Video
 </h3>
-<div class="example" id="example-640">
+<div class="example" id="example-641">
 <div class="examplenum">
-<a href="#example-640">Example 640</a>
+<a href="#example-641">Example 641</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">Here's<span class="space"> </span>a<span class="space"> </span>paragraph<span class="space"> </span>before<span class="space"> </span>the<span class="space"> </span>figure.
@@ -18937,9 +19017,9 @@ Here's<span class="space"> </span>a<span class="space"> </span>paragraph<span cl
 <h3 id="web-video" class="definition">
 <span class="number">11.11.3</span>Web Video
 </h3>
-<div class="example" id="example-641">
+<div class="example" id="example-642">
 <div class="examplenum">
-<a href="#example-641">Example 641</a>
+<a href="#example-642">Example 642</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">Here's<span class="space"> </span>a<span class="space"> </span>paragraph<span class="space"> </span>before<span class="space"> </span>the<span class="space"> </span>figure.
@@ -19007,9 +19087,9 @@ ADA compliance. For example, what Leanpub does with an <code>iframe</code> resou
 <p>In the following sections, please note that while the examples are shown with
 an HTML mapping, please note that a Markua Processor has complete flexibility
 over how it handles the location of video resources and their display.</p>
-<div class="example" id="example-642">
+<div class="example" id="example-643">
 <div class="examplenum">
-<a href="#example-642">Example 642</a>
+<a href="#example-643">Example 643</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">Here's<span class="space"> </span>a<span class="space"> </span>paragraph<span class="space"> </span>before<span class="space"> </span>the<span class="space"> </span>figure.
@@ -19097,9 +19177,9 @@ over how it handles the location of video resources and their display.</p>
 <h3 id="local-audio" class="definition">
 <span class="number">11.13.2</span>Local Audio
 </h3>
-<div class="example" id="example-643">
+<div class="example" id="example-644">
 <div class="examplenum">
-<a href="#example-643">Example 643</a>
+<a href="#example-644">Example 644</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">The<span class="space"> </span>full<span class="space"> </span>version<span class="space"> </span>of<span class="space"> </span>the<span class="space"> </span>talk<span class="space"> </span>is<span class="space"> </span>here:
@@ -19119,9 +19199,9 @@ over how it handles the location of video resources and their display.</p>
 <h3 id="web-audio" class="definition">
 <span class="number">11.13.3</span>Web Audio
 </h3>
-<div class="example" id="example-644">
+<div class="example" id="example-645">
 <div class="examplenum">
-<a href="#example-644">Example 644</a>
+<a href="#example-645">Example 645</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">The<span class="space"> </span>full<span class="space"> </span>version<span class="space"> </span>of<span class="space"> </span>the<span class="space"> </span>talk<span class="space"> </span>is<span class="space"> </span>here:
@@ -19457,9 +19537,9 @@ of 2–32 characters beginning with an ASCII letter and followed
 by any combination of ASCII letters, digits, or the symbols plus
 (“+”), period (“.”), or hyphen (“-”).</p>
 <p>Here are some valid autolinks:</p>
-<div class="example" id="example-645">
+<div class="example" id="example-646">
 <div class="examplenum">
-<a href="#example-645">Example 645</a>
+<a href="#example-646">Example 646</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">&lt;http://foo.bar.baz&gt;
@@ -19470,9 +19550,9 @@ by any combination of ASCII letters, digits, or the symbols plus
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-646">
+<div class="example" id="example-647">
 <div class="examplenum">
-<a href="#example-646">Example 646</a>
+<a href="#example-647">Example 647</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">&lt;https://foo.bar.baz/test?q=hello&amp;id=22&amp;boolean&gt;
@@ -19483,9 +19563,9 @@ by any combination of ASCII letters, digits, or the symbols plus
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-647">
+<div class="example" id="example-648">
 <div class="examplenum">
-<a href="#example-647">Example 647</a>
+<a href="#example-648">Example 648</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">&lt;irc://foo.bar:2233/baz&gt;
@@ -19497,9 +19577,9 @@ by any combination of ASCII letters, digits, or the symbols plus
 </div>
 </div>
 <p>Uppercase is also fine:</p>
-<div class="example" id="example-648">
+<div class="example" id="example-649">
 <div class="examplenum">
-<a href="#example-648">Example 648</a>
+<a href="#example-649">Example 649</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">&lt;MAILTO:FOO@BAR.BAZ&gt;
@@ -19514,9 +19594,9 @@ by any combination of ASCII letters, digits, or the symbols plus
 purposes of this spec are not valid URIs, because their
 schemes are not registered or because of other problems
 with their syntax:</p>
-<div class="example" id="example-649">
+<div class="example" id="example-650">
 <div class="examplenum">
-<a href="#example-649">Example 649</a>
+<a href="#example-650">Example 650</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">&lt;a+b+c:d&gt;
@@ -19527,9 +19607,9 @@ with their syntax:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-650">
+<div class="example" id="example-651">
 <div class="examplenum">
-<a href="#example-650">Example 650</a>
+<a href="#example-651">Example 651</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">&lt;made-up-scheme://foo,bar&gt;
@@ -19540,9 +19620,9 @@ with their syntax:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-651">
+<div class="example" id="example-652">
 <div class="examplenum">
-<a href="#example-651">Example 651</a>
+<a href="#example-652">Example 652</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">&lt;https://../&gt;
@@ -19553,9 +19633,9 @@ with their syntax:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-652">
+<div class="example" id="example-653">
 <div class="examplenum">
-<a href="#example-652">Example 652</a>
+<a href="#example-653">Example 653</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">&lt;localhost:5001/foo&gt;
@@ -19567,9 +19647,9 @@ with their syntax:</p>
 </div>
 </div>
 <p>Spaces are not allowed in autolinks:</p>
-<div class="example" id="example-653">
+<div class="example" id="example-654">
 <div class="examplenum">
-<a href="#example-653">Example 653</a>
+<a href="#example-654">Example 654</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">&lt;https://foo.bar/baz<span class="space"> </span>bim&gt;
@@ -19581,9 +19661,9 @@ with their syntax:</p>
 </div>
 </div>
 <p>Backslash-escapes do not work inside autolinks:</p>
-<div class="example" id="example-654">
+<div class="example" id="example-655">
 <div class="examplenum">
-<a href="#example-654">Example 654</a>
+<a href="#example-655">Example 655</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">&lt;https://example.com/\[\&gt;
@@ -19606,9 +19686,9 @@ spec</a>:</p>
 (?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/
 </code></pre>
 <p>Examples of email autolinks:</p>
-<div class="example" id="example-655">
+<div class="example" id="example-656">
 <div class="examplenum">
-<a href="#example-655">Example 655</a>
+<a href="#example-656">Example 656</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">&lt;foo@bar.example.com&gt;
@@ -19619,9 +19699,9 @@ spec</a>:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-656">
+<div class="example" id="example-657">
 <div class="examplenum">
-<a href="#example-656">Example 656</a>
+<a href="#example-657">Example 657</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">&lt;foo+special@Bar.baz-bar0.com&gt;
@@ -19633,9 +19713,9 @@ spec</a>:</p>
 </div>
 </div>
 <p>Backslash-escapes do not work inside email autolinks:</p>
-<div class="example" id="example-657">
+<div class="example" id="example-658">
 <div class="examplenum">
-<a href="#example-657">Example 657</a>
+<a href="#example-658">Example 658</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">&lt;foo\+@bar.example.com&gt;
@@ -19647,9 +19727,9 @@ spec</a>:</p>
 </div>
 </div>
 <p>These are not autolinks:</p>
-<div class="example" id="example-658">
+<div class="example" id="example-659">
 <div class="examplenum">
-<a href="#example-658">Example 658</a>
+<a href="#example-659">Example 659</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">&lt;&gt;
@@ -19660,9 +19740,9 @@ spec</a>:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-659">
+<div class="example" id="example-660">
 <div class="examplenum">
-<a href="#example-659">Example 659</a>
+<a href="#example-660">Example 660</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">&lt;<span class="space"> </span>https://foo.bar<span class="space"> </span>&gt;
@@ -19673,9 +19753,9 @@ spec</a>:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-660">
+<div class="example" id="example-661">
 <div class="examplenum">
-<a href="#example-660">Example 660</a>
+<a href="#example-661">Example 661</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">&lt;m:abc&gt;
@@ -19686,9 +19766,9 @@ spec</a>:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-661">
+<div class="example" id="example-662">
 <div class="examplenum">
-<a href="#example-661">Example 661</a>
+<a href="#example-662">Example 662</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">&lt;foo.bar.baz&gt;
@@ -19699,9 +19779,9 @@ spec</a>:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-662">
+<div class="example" id="example-663">
 <div class="examplenum">
-<a href="#example-662">Example 662</a>
+<a href="#example-663">Example 663</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">https://example.com
@@ -19712,9 +19792,9 @@ spec</a>:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-663">
+<div class="example" id="example-664">
 <div class="examplenum">
-<a href="#example-663">Example 663</a>
+<a href="#example-664">Example 664</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">foo@bar.example.com
@@ -19741,9 +19821,9 @@ removed from the output.</p>
 by two or more spaces and does not occur at the end of a block
 is parsed as a <a id="hard-line-break" href="#hard-line-break" class="definition">hard line break</a> (rendered
 in HTML as a <code>&lt;br /&gt;</code> tag):</p>
-<div class="example" id="example-664">
+<div class="example" id="example-665">
 <div class="examplenum">
-<a href="#example-664">Example 664</a>
+<a href="#example-665">Example 665</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">foo<span class="space"> </span><span class="space"> </span>
@@ -19758,9 +19838,9 @@ baz&lt;/p&gt;
 </div>
 <p>For a more visible alternative, a backslash before the
 <a href="#line-ending">line ending</a> may be used instead of two or more spaces:</p>
-<div class="example" id="example-665">
+<div class="example" id="example-666">
 <div class="examplenum">
-<a href="#example-665">Example 665</a>
+<a href="#example-666">Example 666</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">foo\
@@ -19774,9 +19854,9 @@ baz&lt;/p&gt;
 </div>
 </div>
 <p>More than two spaces can be used:</p>
-<div class="example" id="example-666">
+<div class="example" id="example-667">
 <div class="examplenum">
-<a href="#example-666">Example 666</a>
+<a href="#example-667">Example 667</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">foo<span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="space"> </span>
@@ -19790,9 +19870,9 @@ baz&lt;/p&gt;
 </div>
 </div>
 <p>Leading spaces at the beginning of the next line are ignored:</p>
-<div class="example" id="example-667">
+<div class="example" id="example-668">
 <div class="examplenum">
-<a href="#example-667">Example 667</a>
+<a href="#example-668">Example 668</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">foo<span class="space"> </span><span class="space"> </span>
@@ -19805,9 +19885,9 @@ bar&lt;/p&gt;
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-668">
+<div class="example" id="example-669">
 <div class="examplenum">
-<a href="#example-668">Example 668</a>
+<a href="#example-669">Example 669</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">foo\
@@ -19822,9 +19902,9 @@ bar&lt;/p&gt;
 </div>
 <p>Hard line breaks can occur inside emphasis, links, and other constructs
 that allow inline content:</p>
-<div class="example" id="example-669">
+<div class="example" id="example-670">
 <div class="examplenum">
-<a href="#example-669">Example 669</a>
+<a href="#example-670">Example 670</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">*foo<span class="space"> </span><span class="space"> </span>
@@ -19837,9 +19917,9 @@ bar&lt;/em&gt;&lt;/p&gt;
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-670">
+<div class="example" id="example-671">
 <div class="examplenum">
-<a href="#example-670">Example 670</a>
+<a href="#example-671">Example 671</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">*foo\
@@ -19853,9 +19933,9 @@ bar&lt;/em&gt;&lt;/p&gt;
 </div>
 </div>
 <p>Hard line breaks do not occur inside code spans</p>
-<div class="example" id="example-671">
+<div class="example" id="example-672">
 <div class="examplenum">
-<a href="#example-671">Example 671</a>
+<a href="#example-672">Example 672</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">`code<span class="space"> </span><span class="space"> </span>
@@ -19867,9 +19947,9 @@ span`
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-672">
+<div class="example" id="example-673">
 <div class="examplenum">
-<a href="#example-672">Example 672</a>
+<a href="#example-673">Example 673</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">`code\
@@ -19882,9 +19962,9 @@ span`
 </div>
 </div>
 <p>or HTML tags:</p>
-<div class="example" id="example-673">
+<div class="example" id="example-674">
 <div class="examplenum">
-<a href="#example-673">Example 673</a>
+<a href="#example-674">Example 674</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">&lt;a<span class="space"> </span>href=&quot;foo<span class="space"> </span><span class="space"> </span>
@@ -19897,9 +19977,9 @@ bar&quot;&gt;&lt;/p&gt;
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-674">
+<div class="example" id="example-675">
 <div class="examplenum">
-<a href="#example-674">Example 674</a>
+<a href="#example-675">Example 675</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">&lt;a<span class="space"> </span>href=&quot;foo\
@@ -19915,9 +19995,9 @@ bar&quot;&gt;&lt;/p&gt;
 <p>Hard line breaks are for separating inline content within a block.
 Neither syntax for hard line breaks works at the end of a paragraph or
 other block element:</p>
-<div class="example" id="example-675">
+<div class="example" id="example-676">
 <div class="examplenum">
-<a href="#example-675">Example 675</a>
+<a href="#example-676">Example 676</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">foo\
@@ -19928,9 +20008,9 @@ other block element:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-676">
+<div class="example" id="example-677">
 <div class="examplenum">
-<a href="#example-676">Example 676</a>
+<a href="#example-677">Example 677</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">foo<span class="space"> </span><span class="space"> </span>
@@ -19941,9 +20021,9 @@ other block element:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-677">
+<div class="example" id="example-678">
 <div class="examplenum">
-<a href="#example-677">Example 677</a>
+<a href="#example-678">Example 678</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">###<span class="space"> </span>foo\
@@ -19954,9 +20034,9 @@ other block element:</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-678">
+<div class="example" id="example-679">
 <div class="examplenum">
-<a href="#example-678">Example 678</a>
+<a href="#example-679">Example 679</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">###<span class="space"> </span>foo<span class="space"> </span><span class="space"> </span>
@@ -19975,9 +20055,9 @@ preceded by two or more spaces or a backslash is parsed as a
 <a id="softbreak" href="#softbreak" class="definition">softbreak</a>.  (A soft line break may be rendered in HTML either as a
 <a href="#line-ending">line ending</a> or as a space. The result will be the same in
 browsers. In the examples here, a <a href="#line-ending">line ending</a> will be used.)</p>
-<div class="example" id="example-679">
+<div class="example" id="example-680">
 <div class="examplenum">
-<a href="#example-679">Example 679</a>
+<a href="#example-680">Example 680</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">foo
@@ -19992,9 +20072,9 @@ baz&lt;/p&gt;
 </div>
 <p>Spaces at the end of the line and beginning of the next line are
 removed:</p>
-<div class="example" id="example-680">
+<div class="example" id="example-681">
 <div class="examplenum">
-<a href="#example-680">Example 680</a>
+<a href="#example-681">Example 681</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">foo<span class="space"> </span>
@@ -20183,9 +20263,9 @@ this is much less of an issue for them!</p>
 issue. While underline does have legitimate uses, they are more niche than
 italic.)</p>
 <p>So, by default, <code>italicize-underlines</code> is <code>true</code>:</p>
-<div class="example" id="example-681">
+<div class="example" id="example-682">
 <div class="examplenum">
-<a href="#example-681">Example 681</a>
+<a href="#example-682">Example 682</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">#<span class="space"> </span>Chapter<span class="space"> </span>One
@@ -20210,9 +20290,9 @@ stuff
 </div>
 <p>This can be made explicit by setting the <code>italicize-underlines</code> document setting
 to <code>true</code>:</p>
-<div class="example" id="example-682">
+<div class="example" id="example-683">
 <div class="examplenum">
-<a href="#example-682">Example 682</a>
+<a href="#example-683">Example 683</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">{
@@ -20240,9 +20320,9 @@ stuff
 </div>
 </div>
 <p>Set the <code>italicize-underlines</code> document setting to <code>false</code> to produce underline:</p>
-<div class="example" id="example-683">
+<div class="example" id="example-684">
 <div class="examplenum">
-<a href="#example-683">Example 683</a>
+<a href="#example-684">Example 684</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">{
@@ -20270,9 +20350,9 @@ stuff
 </div>
 </div>
 <p>To produce text which is underlined as well as other bolded and/or italicized, you combine the underscores for underlining with the asterisks for bold and italics:</p>
-<div class="example" id="example-684">
+<div class="example" id="example-685">
 <div class="examplenum">
-<a href="#example-684">Example 684</a>
+<a href="#example-685">Example 685</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">{
@@ -20304,13 +20384,214 @@ stuff
 </div>
 </div>
 <div class="extension">
+<h2 id="blanks-m-" class="definition">
+<span class="number">11.22</span>Blanks (M)
+</h2>
+<p>Workbooks, study guides and exercise handouts are full of fill-in-the-blank
+lines: a short blank in the middle of a sentence for a missing word, or a
+full-width ruled line for a reader to write a longer answer on.</p>
+<p>Markdown has no syntax for this, so authors resort to hacks: runs of literal
+underscores (which render in most fonts as a broken, gappy line), tables with
+empty cells, or non-breaking spaces sandwiched between underline markers.
+These all look wrong, and none of them can do the one genuinely useful thing
+a blank could do: remember its answer.</p>
+<p>Markua addresses the second need–the full-width ruled line–with no new
+syntax at all: a rule from margin to margin is just one way of <em>rendering</em> a
+thematic break, so it is handled by setting the <code>thematic-break-style</code>
+document setting to <code>full-width-line</code>, as discussed in the
+<a href="#thematic-breaks">section on thematic breaks</a>.</p>
+<p>For the first need–the blank in the middle of a sentence–Markua defines a
+blank element, using the obvious syntax: a run of underscores that looks
+exactly like a blank.</p>
+<p>A <a id="blank" href="#blank" class="definition">blank</a> is a run of four or more consecutive unescaped underscore (<code>_</code>)
+characters which is not immediately preceded or followed by a word character
+(a letter or a digit) or by an underscore:</p>
+<div class="example" id="example-686">
+<div class="examplenum">
+<a href="#example-686">Example 686</a>
+</div>
+<div class="column">
+<pre><code class="language-markdown">The<span class="space"> </span>capital<span class="space"> </span>of<span class="space"> </span>France<span class="space"> </span>is<span class="space"> </span>____.
+</code></pre>
+</div>
+<div class="column">
+<pre><code class="language-html">&lt;p&gt;The<span class="space"> </span>capital<span class="space"> </span>of<span class="space"> </span>France<span class="space"> </span>is<span class="space"> </span>&lt;span<span class="space"> </span>class=&quot;blank&quot;&gt;____&lt;/span&gt;.&lt;/p&gt;
+</code></pre>
+</div>
+</div>
+<p>A blank MUST NOT be rendered as literal underscore characters. Instead, a
+blank MUST be rendered as one continuous horizontal rule at the text
+baseline–in print, the classic fill-in-the-blank line.</p>
+<p>The width of a blank SHOULD be proportional to the length of the run, with
+each underscore corresponding to approximately one character width. To make a
+blank wider, type more underscores:</p>
+<div class="example" id="example-687">
+<div class="examplenum">
+<a href="#example-687">Example 687</a>
+</div>
+<div class="column">
+<pre><code class="language-markdown">Short:<span class="space"> </span>____<span class="space"> </span>or<span class="space"> </span>long:<span class="space"> </span>________________.
+</code></pre>
+</div>
+<div class="column">
+<pre><code class="language-html">&lt;p&gt;Short:<span class="space"> </span>&lt;span<span class="space"> </span>class=&quot;blank&quot;&gt;____&lt;/span&gt;<span class="space"> </span>or<span class="space"> </span>long:<span class="space"> </span>&lt;span<span class="space"> </span>class=&quot;blank&quot;&gt;________________&lt;/span&gt;.&lt;/p&gt;
+</code></pre>
+</div>
+</div>
+<p>Note that the underscores are preserved in the HTML output as the content of
+the span. This is deliberate: it preserves the length of the run for the
+stylesheet to use, and it degrades gracefully–unstyled HTML shows the run of
+underscores, which is exactly what plain Markdown would have shown. However, a
+Markua Processor SHOULD expose a blank to assistive technology as a blank to
+be filled in, not as a string of underscore characters to be read aloud.</p>
+<p>A blank is atomic: it MUST NOT be broken across lines. If you want a blank
+wider than the space remaining on a line, what you actually want is a
+full-width writing line: set the <code>thematic-break-style</code> document setting to
+<code>full-width-line</code> and use thematic breaks.</p>
+<p>Relatedly, a blank is an inline element, so a line consisting of nothing but
+underscores is not a blank at all: it is a
+<a href="#thematic-breaks">thematic break</a>, exactly as in CommonMark, since block
+parsing happens first. In a workbook this is a feature, not a gotcha: with
+<code>thematic-break-style: full-width-line</code>, an author who instinctively types a
+line of underscores to make a line to write on gets exactly that.</p>
+<p>Only isolated runs become blanks. A run of four or more underscores directly
+attached to a word–like <code>____foo____</code>–continues to behave according to the
+<a href="#emphasis-and-strong-emphasis">emphasis rules</a>, and runs of one, two or
+three underscores are unchanged everywhere. An isolated run usually rendered
+as useless literal underscores in CommonMark; in the rare arrangements where
+a punctuation-flanked run could have paired with surrounding emphasis, the
+blank interpretation deliberately wins:</p>
+<div class="example" id="example-688">
+<div class="examplenum">
+<a href="#example-688">Example 688</a>
+</div>
+<div class="column">
+<pre><code class="language-markdown">_one_<span class="space"> </span>__two__<span class="space"> </span>___three___<span class="space"> </span>but<span class="space"> </span>____.
+</code></pre>
+</div>
+<div class="column">
+<pre><code class="language-html">&lt;p&gt;&lt;em&gt;one&lt;/em&gt;<span class="space"> </span>&lt;strong&gt;two&lt;/strong&gt;<span class="space"> </span>&lt;em&gt;&lt;strong&gt;three&lt;/strong&gt;&lt;/em&gt;<span class="space"> </span>but<span class="space"> </span>&lt;span<span class="space"> </span>class=&quot;blank&quot;&gt;____&lt;/span&gt;.&lt;/p&gt;
+</code></pre>
+</div>
+</div>
+<p>Blanks are also orthogonal to the <code>italicize-underlines</code> document setting:
+they work identically whether it is <code>true</code> or <code>false</code>, since a blank is never
+treated as an emphasis (or underline) delimiter in the first place:</p>
+<div class="example" id="example-689">
+<div class="examplenum">
+<a href="#example-689">Example 689</a>
+</div>
+<div class="column">
+<pre><code class="language-markdown">{
+italicize-underlines:<span class="space"> </span>false
+}
+
+#<span class="space"> </span>Chapter<span class="space"> </span>One
+
+Fill<span class="space"> </span>in<span class="space"> </span>the<span class="space"> </span>_important_<span class="space"> </span>word:<span class="space"> </span>____.
+</code></pre>
+</div>
+<div class="column">
+<pre><code class="language-html">&lt;h1&gt;Chapter<span class="space"> </span>One&lt;/h1&gt;
+&lt;p&gt;Fill<span class="space"> </span>in<span class="space"> </span>the<span class="space"> </span>&lt;u&gt;important&lt;/u&gt;<span class="space"> </span>word:<span class="space"> </span>&lt;span<span class="space"> </span>class=&quot;blank&quot;&gt;____&lt;/span&gt;.&lt;/p&gt;
+</code></pre>
+</div>
+</div>
+<p>(This matters because before blanks existed, the only way to fake a
+fill-in-the-blank line in Leanpub was to set <code>italicize-underlines: false</code>
+and sandwich non-breaking spaces between underscores–changing the meaning of
+<code>_emphasis_</code> throughout the entire book in order to buy one blank line.
+Blanks make that hack unnecessary.)</p>
+<p>To produce actual literal underscores, backslash-escape the first one. The
+escaped underscore is ordinary text, and since a run adjacent to an
+underscore does not form a blank, the rest of the run is ordinary text too:</p>
+<div class="example" id="example-690">
+<div class="examplenum">
+<a href="#example-690">Example 690</a>
+</div>
+<div class="column">
+<pre><code class="language-markdown">\_____
+</code></pre>
+</div>
+<div class="column">
+<pre><code class="language-html">&lt;p&gt;_____&lt;/p&gt;
+</code></pre>
+</div>
+</div>
+<h3 id="blanks-with-answers" class="definition">
+<span class="number">11.22.1</span>Blanks with answers
+</h3>
+<p>A blank can remember its answer. Attach the answer with the standard span
+<a href="#attribute-lists-m-">attribute list</a> syntax, the same mechanism used by
+<a href="#index-entries-m-">index entries</a>: add the attribute list immediately after
+the run of underscores.</p>
+<pre><code>The powerhouse of the cell is the ____{answer: &quot;mitochondria&quot;}.
+</code></pre>
+<p>The answer value is a text string; like any attribute value, it should be
+quoted if it contains punctuation or spaces (and it is a best practice to
+always quote it).</p>
+<p>By default, the answer does not appear anywhere in the output–not even as
+metadata. Like the <code>only</code> span attribute, the <code>answer</code> attribute is consumed
+by the Markua Processor, so a reader viewing the HTML source of a web version
+cannot cheat by reading the answers out of the markup:</p>
+<div class="example" id="example-691">
+<div class="examplenum">
+<a href="#example-691">Example 691</a>
+</div>
+<div class="column">
+<pre><code class="language-markdown">The<span class="space"> </span>powerhouse<span class="space"> </span>of<span class="space"> </span>the<span class="space"> </span>cell<span class="space"> </span>is<span class="space"> </span>the<span class="space"> </span>____{answer:<span class="space"> </span>&quot;mitochondria&quot;}.
+</code></pre>
+</div>
+<div class="column">
+<pre><code class="language-html">&lt;p&gt;The<span class="space"> </span>powerhouse<span class="space"> </span>of<span class="space"> </span>the<span class="space"> </span>cell<span class="space"> </span>is<span class="space"> </span>the<span class="space"> </span>&lt;span<span class="space"> </span>class=&quot;blank&quot;&gt;____&lt;/span&gt;.&lt;/p&gt;
+</code></pre>
+</div>
+</div>
+<p>Setting the <code>show-blank-answers</code> document setting to <code>true</code> renders every
+answer inside its blank:</p>
+<div class="example" id="example-692">
+<div class="examplenum">
+<a href="#example-692">Example 692</a>
+</div>
+<div class="column">
+<pre><code class="language-markdown">{
+show-blank-answers:<span class="space"> </span>true
+}
+
+#<span class="space"> </span>Chapter<span class="space"> </span>One
+
+The<span class="space"> </span>powerhouse<span class="space"> </span>of<span class="space"> </span>the<span class="space"> </span>cell<span class="space"> </span>is<span class="space"> </span>the<span class="space"> </span>____{answer:<span class="space"> </span>&quot;mitochondria&quot;}.
+</code></pre>
+</div>
+<div class="column">
+<pre><code class="language-html">&lt;h1&gt;Chapter<span class="space"> </span>One&lt;/h1&gt;
+&lt;p&gt;The<span class="space"> </span>powerhouse<span class="space"> </span>of<span class="space"> </span>the<span class="space"> </span>cell<span class="space"> </span>is<span class="space"> </span>the<span class="space"> </span>&lt;span<span class="space"> </span>class=&quot;blank<span class="space"> </span>filled&quot;&gt;mitochondria&lt;/span&gt;.&lt;/p&gt;
+</code></pre>
+</div>
+</div>
+<p>This means one manuscript can produce both the student edition and the answer
+key or teacher’s edition of a workbook. When answers are shown, the blank
+SHOULD still be rendered as a blank–the answer sitting on a rule–rather
+than as ordinary text, so it remains obvious which words are the answers.</p>
+<p>Note that since the width of a blank comes from the number of underscores and
+not from the answer, the width of a blank does not leak the length of its
+answer–unless you choose to size each blank to fit its answer, of course.</p>
+<p>Finally, note that a blank is typographic: ink on paper. If you want a blank
+which is automatically graded–accepting several answer values, regular
+expressions, and awarding points–that is a
+<a href="#fill-in-the-blank-questions-m-">fill in the blank question</a> in a quiz or
+exercise, which is a different, more powerful thing. However, since a blank
+is a real element with a known answer, a Markua Processor generating an
+interactive format MAY render a blank as an input field.</p>
+</div>
+<div class="extension">
 <h2 id="superscript-and-subscript-m-" class="definition">
-<span class="number">11.22</span>Superscript and subscript (M)
+<span class="number">11.23</span>Superscript and subscript (M)
 </h2>
 <p>To produce superscript like the 3 in 5^3^ = 125, surround it with carets like <code>5^3^ = 125</code>.</p>
-<div class="example" id="example-685">
+<div class="example" id="example-693">
 <div class="examplenum">
-<a href="#example-685">Example 685</a>
+<a href="#example-693">Example 693</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">Superscript:<span class="space"> </span>5^3^<span class="space"> </span>=<span class="space"> </span>125
@@ -20322,9 +20603,9 @@ stuff
 </div>
 </div>
 <p>To produce subscript like the 2 in H~2~O, surround it with single tildes like <code>H~2~O</code>.</p>
-<div class="example" id="example-686">
+<div class="example" id="example-694">
 <div class="examplenum">
-<a href="#example-686">Example 686</a>
+<a href="#example-694">Example 694</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">Subscript:<span class="space"> </span>H~2~O
@@ -20338,14 +20619,14 @@ stuff
 </div>
 <div class="extension">
 <h2 id="strikethrough-gfm-" class="definition">
-<span class="number">11.23</span>Strikethrough (GFM)
+<span class="number">11.24</span>Strikethrough (GFM)
 </h2>
 <p>Markua enables the <code>strikethrough</code> extension, where an additional emphasis type is
 available.</p>
 <p>Strikethrough text is any text wrapped in two tildes (<code>~</code>).</p>
-<div class="example" id="example-687">
+<div class="example" id="example-695">
 <div class="examplenum">
-<a href="#example-687">Example 687</a>
+<a href="#example-695">Example 695</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">~~Hi~~<span class="space"> </span>Hello,<span class="space"> </span>world!
@@ -20358,9 +20639,9 @@ available.</p>
 </div>
 <p>As with regular emphasis delimiters, a new paragraph will cause strikethrough
 parsing to cease:</p>
-<div class="example" id="example-688">
+<div class="example" id="example-696">
 <div class="examplenum">
-<a href="#example-688">Example 688</a>
+<a href="#example-696">Example 696</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">This<span class="space"> </span>~~has<span class="space"> </span>a
@@ -20377,7 +20658,7 @@ new<span class="space"> </span>paragraph~~.
 </div>
 <div class="extension">
 <h2 id="index-entries-m-" class="definition">
-<span class="number">11.24</span>Index entries (M)
+<span class="number">11.25</span>Index entries (M)
 </h2>
 <p>Markua supports adding index entries via the attribute list syntax. Index
 entries let authors or indexers produce professional-looking indexes in
@@ -20386,7 +20667,7 @@ Markua books.</p>
 attribute list syntax. In fact, index entries can just be added as part of a
 larger attribute list.</p>
 <h3 id="how-to-insert-an-index-entry" class="definition">
-<span class="number">11.24.1</span>How to Insert an Index Entry
+<span class="number">11.25.1</span>How to Insert an Index Entry
 </h3>
 <p>To insert an index entry, you need to <strong>attach it</strong> to a block or span element.</p>
 <p><strong>You MUST attach an index entry to something, e.g. <code>a word{i: &quot;an index entry&quot;}</code>.
@@ -20413,7 +20694,7 @@ a block:</p>
 I just came to say hello, hello, hello, hello
 </code></pre>
 <h3 id="index-entry-format" class="definition">
-<span class="number">11.24.2</span>Index Entry Format
+<span class="number">11.25.2</span>Index Entry Format
 </h3>
 <p>The actual syntax of what the value of an index entry looks like is <a href="https://en.wikibooks.org/wiki/LaTeX/Indexing">inspired
 by LaTeX</a>.</p>
@@ -20500,14 +20781,14 @@ as an attempt at creating a sub-entry. (This actually got me, when I tried to
 reference <em>Hello! Flex 4</em>, one of my books. To do this, I would have to write
 the entry as <code>{i: &quot;*Hello\! Flex 4*}</code> not as <code>{i: &quot;*Hello! Flex 4*}</code>.</p>
 <h3 id="index-output-format" class="definition">
-<span class="number">11.24.3</span>Index Output Format
+<span class="number">11.25.3</span>Index Output Format
 </h3>
 <p>Markua does not specify the format of the HTML output of the actual index itself,
 to maximize implementation flexibility.</p>
 </div>
 <div class="extension">
 <h2 id="syntactic-sugar-list-m-" class="definition">
-<span class="number">11.25</span>Syntactic sugar list (M)
+<span class="number">11.26</span>Syntactic sugar list (M)
 </h2>
 <p>Markua has a handful of syntactic sugar that it relies on to make life nicer for
 authors. Here’s a helpful summary list of the different syntactic sugar elements
@@ -20533,13 +20814,13 @@ a <code>{class: continued-para}</code></p>
 : <code>{format: text}</code></p>
 </div>
 <h2 id="textual-content" class="definition">
-<span class="number">11.26</span>Textual content
+<span class="number">11.27</span>Textual content
 </h2>
 <p>Any characters not given an interpretation by the above rules will
 be parsed as plain textual content.</p>
-<div class="example" id="example-689">
+<div class="example" id="example-697">
 <div class="examplenum">
-<a href="#example-689">Example 689</a>
+<a href="#example-697">Example 697</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">hello<span class="space"> </span>$.;'there
@@ -20550,9 +20831,9 @@ be parsed as plain textual content.</p>
 </code></pre>
 </div>
 </div>
-<div class="example" id="example-690">
+<div class="example" id="example-698">
 <div class="examplenum">
-<a href="#example-690">Example 690</a>
+<a href="#example-698">Example 698</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">Foo<span class="space"> </span>χρῆν
@@ -20564,9 +20845,9 @@ be parsed as plain textual content.</p>
 </div>
 </div>
 <p>Internal spaces are preserved verbatim:</p>
-<div class="example" id="example-691">
+<div class="example" id="example-699">
 <div class="examplenum">
-<a href="#example-691">Example 691</a>
+<a href="#example-699">Example 699</a>
 </div>
 <div class="column">
 <pre><code class="language-markdown">Multiple<span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="space"> </span>spaces

--- a/spec.txt
+++ b/spec.txt
@@ -1,8 +1,8 @@
 ---
 title: Markua Spec
 author: '*This formal specification of Markua was developed at [Leanpub](https://leanpub.com), is written by Peter Armstrong, is based on the CommonMark Spec (version 0.31.2) by John MacFarlane, and is licensed under the Creative Commons license CC-BY-SA 4.0.*<br/><br/><hr/><br/>NOTE: If you are a Leanpub author, there are two different versions of Markua used on Leanpub. <strong>The default version of Markua for books on Leanpub is Markua 0.30, which is documented in this specification, and which is currently in beta on Leanpub.</strong> The default version of Markua for courses on Leanpub is still Markua 0.10, which is documented in [The Markua Manual](https://leanpub.com/markua/read). (You can still use Markua 0.10 and Leanpub Flavoured Markdown for books on Leanpub, of course.)<br/><br/><hr/><br/>'
-version: '0.31.50'
-date: '2026-08-11'
+version: '0.31.51'
+date: '2026-08-12'
 license: '[CC-BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/)'
 ...
 

--- a/spec.txt
+++ b/spec.txt
@@ -17804,10 +17804,10 @@ line of underscores to make a line to write on gets exactly that.
 Only isolated runs become blanks. A run of four or more underscores directly
 attached to a word--like `____foo____`--continues to behave according to the
 [emphasis rules](#emphasis-and-strong-emphasis), and runs of one, two or
-three underscores are unchanged everywhere. In practice, the blank syntax
-claims only sequences which, in CommonMark, can never pair as emphasis
-delimiters anyway, and which would therefore have rendered as useless literal
-underscores:
+three underscores are unchanged everywhere. An isolated run usually rendered
+as useless literal underscores in CommonMark; in the rare arrangements where
+a punctuation-flanked run could have paired with surrounding emphasis, the
+blank interpretation deliberately wins:
 
 ```````````````````````````````` example
 _one_ __two__ ___three___ but ____.

--- a/spec.txt
+++ b/spec.txt
@@ -3234,6 +3234,7 @@ the defaults are in one list. These defaults are listed below.
   restart-endnote-numbering: true
   restart-footnote-numbering: true
   section-number-format: name
+  show-blank-answers: false
   soft-breaks: space
   table-name: figure
   toc-chapter-number-format: name
@@ -3410,6 +3411,13 @@ at the end of a chapter.
 the section heading in the body of the book. The format of the section heading
 in the table of contents is set by the related `toc-section-number-format`
 setting.
+
+`show-blank-answers`
+: `true` or `false`. The default value is `false`. If `false`, the `answer`
+attribute of a [blank](#blanks-m-) is consumed and does not appear in the
+output. If `true`, every answer is rendered inside its blank, so that one
+manuscript can produce both the student edition and the answer key or
+teacher's edition of a workbook. This is discussed [here](#blanks-m-).
 
 `soft-breaks`
 : `break` or `space`. The default is `space`, for compatibility with
@@ -4547,9 +4555,23 @@ Foo
 More than three characters may be used:
 
 ```````````````````````````````` example
-_____________________________________
+*************************************
 .
 <hr />
+````````````````````````````````
+
+
+Note that in CommonMark, a long line of underscores is also a thematic break.
+In Markua it is not: a line consisting of four or more underscores is a
+[block blank](#blanks-m-) instead--a full-width ruled line for the reader to
+write on--since that is what such a line looks like. A line of exactly three
+underscores (`___`), as in the first example above, is still a thematic
+break, for Markdown compatibility:
+
+```````````````````````````````` example
+_____________________________________
+.
+<hr class="blank" />
 ````````````````````````````````
 
 
@@ -13781,8 +13803,13 @@ __ is not an empty emphasis
 ```````````````````````````````` example
 ____ is not an empty strong emphasis
 .
-<p>____ is not an empty strong emphasis</p>
+<p><span class="blank">____</span> is not an empty strong emphasis</p>
 ````````````````````````````````
+
+
+(In CommonMark, the `____` in the previous example would render as four
+literal underscores. In Markua, an isolated run of four or more underscores
+is a [blank](#blanks-m-). Either way, it is not emphasis.)
 
 
 
@@ -13903,8 +13930,13 @@ foo _*_
 ```````````````````````````````` example
 foo _____
 .
-<p>foo _____</p>
+<p>foo <span class="blank">_____</span></p>
 ````````````````````````````````
+
+
+(As above, in CommonMark the `_____` would render as five literal
+underscores; in Markua, an isolated run of four or more underscores is a
+[blank](#blanks-m-).)
 
 
 ```````````````````````````````` example
@@ -17639,6 +17671,270 @@ stuff
 <p>This is <u><strong>bolded and underlined</strong></u>.</p>
 <p>This is <u><strong><em>bolded and italicized and underlined</em></strong></u>.</p>
 <p>stuff</p>
+````````````````````````````````
+
+</div>
+
+
+
+<div class="extension">
+
+## Blanks (M)
+
+Workbooks, study guides and exercise handouts are full of fill-in-the-blank
+lines: a short blank in the middle of a sentence for a missing word, or a
+full-width ruled line for a reader to write a longer answer on.
+
+Markdown has no syntax for this, so authors resort to hacks: runs of literal
+underscores (which render in most fonts as a broken, gappy line), tables with
+empty cells, or non-breaking spaces sandwiched between underline markers.
+These all look wrong, and none of them can do the one genuinely useful thing
+a blank could do: remember its answer.
+
+So Markua defines a blank element, using the obvious syntax: a run of
+underscores that looks exactly like a blank.
+
+### Inline blanks
+
+A [blank](@) is a run of four or more consecutive unescaped underscore (`_`)
+characters which is not immediately preceded or followed by a word character
+(a letter or a digit) or by an underscore:
+
+```````````````````````````````` example
+The capital of France is ____.
+.
+<p>The capital of France is <span class="blank">____</span>.</p>
+````````````````````````````````
+
+
+A blank MUST NOT be rendered as literal underscore characters. Instead, a
+blank MUST be rendered as one continuous horizontal rule at the text
+baseline--in print, the classic fill-in-the-blank line.
+
+The width of a blank SHOULD be proportional to the length of the run, with
+each underscore corresponding to approximately one character width. To make a
+blank wider, type more underscores:
+
+```````````````````````````````` example
+Short: ____ or long: ________________.
+.
+<p>Short: <span class="blank">____</span> or long: <span class="blank">________________</span>.</p>
+````````````````````````````````
+
+
+Note that the underscores are preserved in the HTML output as the content of
+the span. This is deliberate: it preserves the length of the run for the
+stylesheet to use, and it degrades gracefully--unstyled HTML shows the run of
+underscores, which is exactly what plain Markdown would have shown. However, a
+Markua Processor SHOULD expose a blank to assistive technology as a blank to
+be filled in, not as a string of underscore characters to be read aloud.
+
+A blank is atomic: it MUST NOT be broken across lines. If you want a blank
+wider than the space remaining on a line, use a block blank instead (below).
+
+Only isolated runs become blanks. A run of four or more underscores directly
+attached to a word--like `____foo____`--continues to behave according to the
+[emphasis rules](#emphasis-and-strong-emphasis), and runs of one, two or
+three underscores are unchanged everywhere. In practice, the blank syntax
+claims only sequences which, in CommonMark, can never pair as emphasis
+delimiters anyway, and which would therefore have rendered as useless literal
+underscores:
+
+```````````````````````````````` example
+_one_ __two__ ___three___ but ____.
+.
+<p><em>one</em> <strong>two</strong> <em><strong>three</strong></em> but <span class="blank">____</span>.</p>
+````````````````````````````````
+
+
+Blanks are also orthogonal to the `italicize-underlines` document setting:
+they work identically whether it is `true` or `false`, since a blank is never
+treated as an emphasis (or underline) delimiter in the first place:
+
+```````````````````````````````` example
+{
+italicize-underlines: false
+}
+
+# Chapter One
+
+Fill in the _important_ word: ____.
+.
+<h1>Chapter One</h1>
+<p>Fill in the <u>important</u> word: <span class="blank">____</span>.</p>
+````````````````````````````````
+
+
+(This matters because before blanks existed, the only way to fake a
+fill-in-the-blank line in Leanpub was to set `italicize-underlines: false`
+and sandwich non-breaking spaces between underscores--changing the meaning of
+`_emphasis_` throughout the entire book in order to buy one blank line.
+Blanks make that hack unnecessary.)
+
+To produce actual literal underscores, backslash-escape the first one. The
+escaped underscore is ordinary text, and since a run adjacent to an
+underscore does not form a blank, the rest of the run is ordinary text too:
+
+```````````````````````````````` example
+\_____
+.
+<p>_____</p>
+````````````````````````````````
+
+
+### Blanks with answers
+
+A blank can remember its answer. Attach the answer with the standard span
+[attribute list](#attribute-lists-m-) syntax, the same mechanism used by
+[index entries](#index-entries-m-): add the attribute list immediately after
+the run of underscores.
+
+~~~
+The powerhouse of the cell is the ____{answer: "mitochondria"}.
+~~~
+
+The answer value is a text string; like any attribute value, it should be
+quoted if it contains punctuation or spaces (and it is a best practice to
+always quote it).
+
+By default, the answer does not appear anywhere in the output--not even as
+metadata. Like the `only` span attribute, the `answer` attribute is consumed
+by the Markua Processor, so a reader viewing the HTML source of a web version
+cannot cheat by reading the answers out of the markup:
+
+```````````````````````````````` example
+The powerhouse of the cell is the ____{answer: "mitochondria"}.
+.
+<p>The powerhouse of the cell is the <span class="blank">____</span>.</p>
+````````````````````````````````
+
+
+Setting the `show-blank-answers` document setting to `true` renders every
+answer inside its blank:
+
+```````````````````````````````` example
+{
+show-blank-answers: true
+}
+
+# Chapter One
+
+The powerhouse of the cell is the ____{answer: "mitochondria"}.
+.
+<h1>Chapter One</h1>
+<p>The powerhouse of the cell is the <span class="blank filled">mitochondria</span>.</p>
+````````````````````````````````
+
+
+This means one manuscript can produce both the student edition and the answer
+key or teacher's edition of a workbook. When answers are shown, the blank
+SHOULD still be rendered as a blank--the answer sitting on a rule--rather
+than as ordinary text, so it remains obvious which words are the answers.
+
+Note that since the width of a blank comes from the number of underscores and
+not from the answer, the width of a blank does not leak the length of its
+answer--unless you choose to size each blank to fit its answer, of course.
+
+Finally, note that a blank is typographic: ink on paper. If you want a blank
+which is automatically graded--accepting several answer values, regular
+expressions, and awarding points--that is a
+[fill in the blank question](#fill-in-the-blank-questions-m-) in a quiz or
+exercise, which is a different, more powerful thing. However, since a blank
+is a real element with a known answer, a Markua Processor generating an
+interactive format MAY render a blank as an input field.
+
+### Block blanks
+
+A line consisting solely of a run of four or more underscores (with up to
+three spaces of indentation, optionally followed by spaces or tabs) is a
+[block blank](@): a full-width ruled line for the reader to write on.
+
+```````````````````````````````` example
+Describe your approach:
+
+________
+.
+<p>Describe your approach:</p>
+<hr class="blank" />
+````````````````````````````````
+
+
+The number of underscores in a block blank does not matter beyond the minimum
+of four: a block blank is always the full width of the text column, a rule
+from margin to margin.
+
+This is a place where Markua deliberately diverges from CommonMark, which
+treats any line of three or more underscores as a
+[thematic break](#thematic-breaks). In Markua, only a line of exactly three
+underscores (`___`) is a thematic break; four or more make a block blank. A
+line of underscores looks exactly like a blank line to write on, which is why
+authors keep trying to use it as one; Markua makes it mean what it looks
+like. Use `---` or `***` for thematic breaks, which is what almost everyone
+does anyway. The spaced form (`_ _ _`) also remains a thematic break at any
+length, since a blank must be one solid run:
+
+```````````````````````````````` example
+___
+
+____
+
+_ _ _ _ _
+.
+<hr />
+<hr class="blank" />
+<hr />
+````````````````````````````````
+
+
+Like a thematic break, a block blank can interrupt a paragraph:
+
+```````````````````````````````` example
+Name:
+____
+.
+<p>Name:</p>
+<hr class="blank" />
+````````````````````````````````
+
+
+(If you want a short inline blank after the label instead, put it on the same
+line: `Name: ____`.)
+
+For longer answers, use the `lines` attribute to produce multiple ruled
+lines:
+
+```````````````````````````````` example
+{lines: 3}
+________
+.
+<hr class="blank" />
+<hr class="blank" />
+<hr class="blank" />
+````````````````````````````````
+
+
+The spacing between the lines is left to the implementation, but SHOULD be
+generous enough to handwrite on--these lines exist for pens, not cursors.
+
+A block blank takes an `answer` attribute too, in a block attribute list on
+the line above it. It behaves the same way as on an inline blank: consumed by
+default, rendered when `show-blank-answers` is `true`:
+
+```````````````````````````````` example
+{
+show-blank-answers: true
+}
+
+# Chapter One
+
+Why did the test fail?
+
+{answer: "Because the cache key omitted the locale."}
+________
+.
+<h1>Chapter One</h1>
+<p>Why did the test fail?</p>
+<div class="blank filled">Because the cache key omitted the locale.</div>
 ````````````````````````````````
 
 </div>

--- a/spec.txt
+++ b/spec.txt
@@ -3237,6 +3237,7 @@ the defaults are in one list. These defaults are listed below.
   show-blank-answers: false
   soft-breaks: space
   table-name: figure
+  thematic-break-style: rule
   toc-chapter-number-format: name
   toc-part-number-format: name
   toc-section-number-format: name
@@ -3435,6 +3436,16 @@ This is what tables get referred to as in crosslinks and lists of figures.
 The reason that this is standardized on two choices, instead of just an
 arbitrary string, is to make things more consistent for readers, and easier to
 implement for builders of Markua Processors.
+
+`thematic-break-style`
+: `rule`, `asterism`, `space` or `full-width-line`. The default is `rule`.
+This setting controls how thematic breaks are rendered: as a conventional
+horizontal rule (`rule`), as a centered scene break ornament (`asterism`),
+as blank vertical space (`space`), or as a full-width ruled line for the
+reader to write an answer on (`full-width-line`), which is the writing line
+found in workbooks and study guides. Parsing is unaffected: this is purely
+a rendering choice. This is discussed in the
+[section on thematic breaks](#thematic-breaks).
 
 `toc-chapter-number-format`
 : `category_number_name` (e.g. Chapter 1: The Chapter Name), `category_number`
@@ -4555,23 +4566,9 @@ Foo
 More than three characters may be used:
 
 ```````````````````````````````` example
-*************************************
-.
-<hr />
-````````````````````````````````
-
-
-Note that in CommonMark, a long line of underscores is also a thematic break.
-In Markua it is not: a line consisting of four or more underscores is a
-[block blank](#blanks-m-) instead--a full-width ruled line for the reader to
-write on--since that is what such a line looks like. A line of exactly three
-underscores (`___`), as in the first example above, is still a thematic
-break, for Markdown compatibility:
-
-```````````````````````````````` example
 _____________________________________
 .
-<hr class="blank" />
+<hr />
 ````````````````````````````````
 
 
@@ -4709,6 +4706,64 @@ If you want a thematic break in a list item, use a different bullet:
 </li>
 </ul>
 ````````````````````````````````
+
+
+How a thematic break is rendered is a different question from how it is
+parsed, and it is a question authors genuinely care about: a novelist may
+want a scene break rendered as blank vertical space or as a centered
+asterism, while a workbook author may want a full-width ruled line for the
+reader to write an answer on. In Markua, this choice is the
+`thematic-break-style` document setting. Its value is one of the following:
+
+`rule`
+: The default: a conventional horizontal rule, used as a separator.
+
+`asterism`
+: A centered scene break ornament: traditionally three stars (⁂), often
+rendered as three spaced asterisks.
+
+`space`
+: Blank vertical space, the way scene breaks are most commonly typeset in
+novels.
+
+`full-width-line`
+: A rule from margin to margin, with generous vertical space around it, for
+the reader to write on. This is the writing line found in workbooks and
+study guides--these lines exist for pens, not cursors. (For a short blank
+inside a sentence, see [blanks](#blanks-m-).)
+
+With the default `rule`, the HTML output is a plain `<hr />`, as in all of
+the examples above. With any other value, the value is emitted as the class
+of the `hr` element, and the actual appearance is up to the stylesheet or
+Markua Processor:
+
+```````````````````````````````` example
+{
+thematic-break-style: full-width-line
+}
+
+# Chapter One
+
+List three examples of irony:
+
+---
+---
+---
+.
+<h1>Chapter One</h1>
+<p>List three examples of irony:</p>
+<hr class="full-width-line" />
+<hr class="full-width-line" />
+<hr class="full-width-line" />
+````````````````````````````````
+
+
+Note that since a thematic break is parsed exactly as it is in CommonMark,
+this feature involves no divergence from CommonMark at all: it is purely a
+rendering choice, made the same way Markua makes other rendering choices,
+with a document setting. Like any document setting, `thematic-break-style`
+applies to the whole document. This setting is also listed in the
+[section on standard document settings](#the-standard-document-settings-m-).
 
 
 ## ATX headings
@@ -17691,10 +17746,15 @@ empty cells, or non-breaking spaces sandwiched between underline markers.
 These all look wrong, and none of them can do the one genuinely useful thing
 a blank could do: remember its answer.
 
-So Markua defines a blank element, using the obvious syntax: a run of
-underscores that looks exactly like a blank.
+Markua addresses the second need--the full-width ruled line--with no new
+syntax at all: a rule from margin to margin is just one way of *rendering* a
+thematic break, so it is handled by setting the `thematic-break-style`
+document setting to `full-width-line`, as discussed in the
+[section on thematic breaks](#thematic-breaks).
 
-### Inline blanks
+For the first need--the blank in the middle of a sentence--Markua defines a
+blank element, using the obvious syntax: a run of underscores that looks
+exactly like a blank.
 
 A [blank](@) is a run of four or more consecutive unescaped underscore (`_`)
 characters which is not immediately preceded or followed by a word character
@@ -17730,7 +17790,16 @@ Markua Processor SHOULD expose a blank to assistive technology as a blank to
 be filled in, not as a string of underscore characters to be read aloud.
 
 A blank is atomic: it MUST NOT be broken across lines. If you want a blank
-wider than the space remaining on a line, use a block blank instead (below).
+wider than the space remaining on a line, what you actually want is a
+full-width writing line: set the `thematic-break-style` document setting to
+`full-width-line` and use thematic breaks.
+
+Relatedly, a blank is an inline element, so a line consisting of nothing but
+underscores is not a blank at all: it is a
+[thematic break](#thematic-breaks), exactly as in CommonMark, since block
+parsing happens first. In a workbook this is a feature, not a gotcha: with
+`thematic-break-style: full-width-line`, an author who instinctively types a
+line of underscores to make a line to write on gets exactly that.
 
 Only isolated runs become blanks. A run of four or more underscores directly
 attached to a word--like `____foo____`--continues to behave according to the
@@ -17842,100 +17911,6 @@ expressions, and awarding points--that is a
 exercise, which is a different, more powerful thing. However, since a blank
 is a real element with a known answer, a Markua Processor generating an
 interactive format MAY render a blank as an input field.
-
-### Block blanks
-
-A line consisting solely of a run of four or more underscores (with up to
-three spaces of indentation, optionally followed by spaces or tabs) is a
-[block blank](@): a full-width ruled line for the reader to write on.
-
-```````````````````````````````` example
-Describe your approach:
-
-________
-.
-<p>Describe your approach:</p>
-<hr class="blank" />
-````````````````````````````````
-
-
-The number of underscores in a block blank does not matter beyond the minimum
-of four: a block blank is always the full width of the text column, a rule
-from margin to margin.
-
-This is a place where Markua deliberately diverges from CommonMark, which
-treats any line of three or more underscores as a
-[thematic break](#thematic-breaks). In Markua, only a line of exactly three
-underscores (`___`) is a thematic break; four or more make a block blank. A
-line of underscores looks exactly like a blank line to write on, which is why
-authors keep trying to use it as one; Markua makes it mean what it looks
-like. Use `---` or `***` for thematic breaks, which is what almost everyone
-does anyway. The spaced form (`_ _ _`) also remains a thematic break at any
-length, since a blank must be one solid run:
-
-```````````````````````````````` example
-___
-
-____
-
-_ _ _ _ _
-.
-<hr />
-<hr class="blank" />
-<hr />
-````````````````````````````````
-
-
-Like a thematic break, a block blank can interrupt a paragraph:
-
-```````````````````````````````` example
-Name:
-____
-.
-<p>Name:</p>
-<hr class="blank" />
-````````````````````````````````
-
-
-(If you want a short inline blank after the label instead, put it on the same
-line: `Name: ____`.)
-
-For longer answers, use the `lines` attribute to produce multiple ruled
-lines:
-
-```````````````````````````````` example
-{lines: 3}
-________
-.
-<hr class="blank" />
-<hr class="blank" />
-<hr class="blank" />
-````````````````````````````````
-
-
-The spacing between the lines is left to the implementation, but SHOULD be
-generous enough to handwrite on--these lines exist for pens, not cursors.
-
-A block blank takes an `answer` attribute too, in a block attribute list on
-the line above it. It behaves the same way as on an inline blank: consumed by
-default, rendered when `show-blank-answers` is `true`:
-
-```````````````````````````````` example
-{
-show-blank-answers: true
-}
-
-# Chapter One
-
-Why did the test fail?
-
-{answer: "Because the cache key omitted the locale."}
-________
-.
-<h1>Chapter One</h1>
-<p>Why did the test fail?</p>
-<div class="blank filled">Because the cache key omitted the locale.</div>
-````````````````````````````````
 
 </div>
 


### PR DESCRIPTION
Adds fill-in-the-blank support for workbooks, in two parts designed for minimal divergence from CommonMark:

## Blanks (M) — new section in Inlines

A **blank** is a run of four or more consecutive unescaped underscores not immediately preceded or followed by a word character or an underscore:

```
The capital of France is ____.
```

- Renders as one **continuous rule at the baseline** — never as literal underscore glyphs (the gappy line every current workaround produces). Width is proportional to the run length; blanks are atomic (never break across lines).
- **Answers**: `____{answer: "mitochondria"}` via the standard span attribute list. Consumed by default — the answer must not survive into any output, so web readers can't view-source it. The new `show-blank-answers` document setting renders answers into their blanks (`class="blank filled"`), so one manuscript produces both the student edition and the teacher's edition / answer key.
- **Escape hatch**: `\_____` renders literal underscores (a run adjacent to an underscore never forms a blank, and maximal consumption means an adjacent underscore can only come from an escape).
- Word-adjacent runs (`____foo____`) keep their emphasis behavior; 1–3-underscore runs are unchanged everywhere; underscore-only lines remain thematic breaks exactly as in CommonMark.

The only changes to inherited CommonMark examples are the two isolated-run emphasis examples (`____ is not an empty strong emphasis`, `foo _____`), which now show blank output — sequences that rendered as useless literal underscores. One honesty note baked into the prose (bf35b63): CommonMark's flanking rules admit punctuation-adjacent `_` delimiters, so in rare arrangements a claimed run could have paired with surrounding underscore emphasis — the blank interpretation deliberately wins.

## thematic-break-style — new document setting

Full-width writing lines needed **no new syntax**: a margin-to-margin rule is just one way of *rendering* a thematic break. The setting (`rule` | `asterism` | `space` | `full-width-line`, default `rule`) picks the rendering; parsing of `---`/`***`/`___` is untouched CommonMark. `full-width-line` is the workbook writing line (three `---` lines = three ruled lines to write on), and novelists get scene-break styling (`asterism`, `space`) from the same setting. Registered in the standard document settings.

## Motivation

This replaces the `italicize-underlines: false` + `&nbsp;`-sandwich hack — which changes the meaning of `_emphasis_` for the whole book to buy one blank line, renders as a broken line, and cannot carry an answer.

## Status

The full implementation exists and is verified in Leanpub's Markua 0.30 pipeline (rubosstech/leanpub#7789, PROD-12188): reader, all output formats, conformance tests running this spec's example blocks (699×2 corpus fixpoint sweep + section harnesses green), and a deep review pass. Per plan, this spec PR merges once that implementation has passed human testing in real books.

Branch history: the two design commits, a review-driven prose correction (`bf35b63`), a master merge (0.31.49 + 0.31.50 changes — no interaction with these sections), and the version bump to **0.31.51**. `spec.html` is not regenerated here — release flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S2LvkUShdGJiCEdnPmSWXS
