### PR TITLE
Remove the stale note saying lang-* directives are unsupported on Leanpub

### DIFF
--- a/spec.txt
+++ b/spec.txt
@@ -2796,10 +2796,6 @@ not use the default language would get annoying very quickly! This is why the
 
 ### The `lang-*` directives
 
-**NOTE FOR LEANPUB AUTHORS: The `lang-*` directives are not yet supported on
-Leanpub. We will add support for them sometime in Q1 2024, and remove this
-note (TODO) when this is done.**
-
 The `lang-*` directives set a new default language. This will be the default
 language until another `lang-*` directive is encountered.
 


### PR DESCRIPTION
Removes the stale note in §"The `lang-*` directives":

> **NOTE FOR LEANPUB AUTHORS: The `lang-*` directives are not yet supported on Leanpub. We will add support for them sometime in Q1 2024, and remove this note (TODO) when this is done.**

They are supported. Verified three ways:

**1. Behaviorally, against the production pandoc build** — `{lang-jpn}` … `{lang-eng}` through Leanpub's own writers:

| Writer | Output |
|---|---|
| `lpubhtml` (web / EPUB) | `<section xml:lang="jpn" dir="ltr" class="lang-directive">` |
| `lpublatex` (PDF) | `\begin{japanese}` … `\end{japanese}` |

Language tagging with text direction on the web side; real font environments on the PDF side.

**2. In shipped code on `main`** — the directive is recognized in the shared helper (`isLangDirective` / `extractLangFromLangDirective`), and both writers track it as document state (`stCurrentLangDirectiveLang`) and wrap blocks accordingly.

**3. Covered by tests and the canonical corpus** — the Markua reader test pins that the family preserves its full name (`lang-jpn` / `lang-fr` / `lang-en-GB`, so the language code survives to the writers), the LaTeX writer tests cover the wrapping, and the canonical `ms_04_language` manuscript exercises all three language mechanisms (`lang` setting, `lang` attribute, `lang-*` directives) together.

Behavior also matches the rest of the section as written: an unrecognized language code falls back to `eng` and LTR (that refinement landed 2026-06-15).

Only the note is removed — no other text in the section changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N6WADpa6rFX4A2v1kDt9fT
